### PR TITLE
Document AI-callable evidence tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The goal is to answer questions ordinary traces do not answer well:
 - [Security Evidence Commands](#security-evidence-commands)
 - [External Evaluator Protocol](#external-evaluator-protocol)
 - [Compliance Evidence, Not Certification](#compliance-evidence-not-certification)
+- [AI-Callable Evidence Tools](#ai-callable-evidence-tools)
 - [Graph Commands](#graph-commands)
 - [Current Capability](#current-capability)
 - [Core Demo Acceptance](#core-demo-acceptance)
@@ -508,6 +509,9 @@ causal graph.
 ./agentprov compliance explain --framework owasp-asi --run <run_id> --item ASI05
 ./agentprov compliance gaps --framework owasp-asi --run <run_id>
 ./agentprov compliance report --framework nist-rfi-2026-00206 --run <run_id>
+./agentprov ai tools --provider openai
+./agentprov ai tools --provider anthropic
+./agentprov ai call evaluate_action --input '{"event_type":"network_connect","dst_ip":"169.254.169.254"}'
 ./agentprov policy test examples/events/metadata-egress.jsonl
 ./agentprov policy decisions --run <run_id>
 ./agentprov forensics export <run_id>
@@ -534,6 +538,7 @@ These commands are now part of the mainline security evidence surface:
 | `baseline learn/check` | Learn process/file/network/risk/runtime feature vectors and emit deviation records plus baseline-derived risk signals |
 | `signal context/batch-context/run/import/import-batch` | Export one `EvalContext` or JSONL `EvalContext` streams for a batch/shard/run list, run built-in or external evaluators, and validate imported `EvalSignal` records or JSONL `EvalReport` batches for reward shaping, dataset filtering, quality scoring, or external benchmark consumers. AgentProvenance owns the evidence protocol, not the reward policy |
 | `compliance frameworks/map/explain/gaps/report` | Map run evidence to OWASP Agentic Security and NIST AI agent security assessment profiles as item-level self-assessment evidence and gap lists |
+| `ai tools/call` | Expose the read-only evidence query surface and inline policy pre-flight gate as provider tool schemas plus a local dispatcher. This is not an LLM gateway: models can query evidence and ask for a trusted policy verdict, but they cannot fabricate runtime telemetry, signatures, or provenance objects |
 | `policy test/decisions` | Evaluate events, persist policy decisions, and feed the risk/response graph |
 | `forensics export` | Export auditable evidence for a run; `--json` emits `agentprovenance.forensics_export/v1` with bundle path, sha256, size, and status |
 | `forensics export-batch` | Export a batch-level audit bundle for record batches; `--json` emits `agentprovenance.batch_forensics_export/v1` with batch summary, per-run forensics refs, optional EvalContext records, result/page hashes, and a sha256-verified bundle path |
@@ -625,6 +630,40 @@ The YAML model separates `rules`, `frameworks`, and `mappings`; mappings can
 also select built-in items such as `ASI05`, `ASI10`, or `TRACE` and reuse them
 inside an enterprise-specific review profile. JSON keeps `control_id` for
 compatibility and also emits `item_id` for the current terminology.
+
+## AI-Callable Evidence Tools
+
+AgentProvenance can expose its evidence query surface as AI-callable tools for
+agent harnesses, evaluators, or review assistants:
+
+```sh
+./agentprov ai tools --provider generic
+./agentprov ai tools --provider openai
+./agentprov ai tools --provider anthropic
+
+./agentprov ai call verify_run --input '{"run":"run-demo-bugfix"}'
+./agentprov ai call list_events --input '{"run":"run-demo-bugfix","type":"execve","limit":10}'
+./agentprov ai call get_timeline --input '{"run":"run-demo-bugfix","view":"causality"}'
+./agentprov ai call evaluate_action --input '{"event_type":"execve","args":["python","-m","pytest","-q"]}'
+./agentprov ai call evaluate_action --input '{"event_type":"network_connect","dst_ip":"169.254.169.254"}'
+```
+
+The catalog currently includes:
+
+| Tool | Purpose |
+|---|---|
+| `verify_run` | Verify object hashes, parent links, and policy/risk/response/signal integrity for a run |
+| `get_signals` | Return the unified behavior/cost/quality/security signal set for a run |
+| `list_risks` | Return security risk signals and recommended actions |
+| `list_events` | Return paged runtime telemetry events, optionally filtered by type |
+| `get_timeline` | Return the merged application-context and runtime-telemetry timeline |
+| `evaluate_action` | Run a proposed command, file action, or network action through the trusted policy engine without executing it |
+
+This is not a model gateway, prompt router, or tool-execution sandbox. The model
+receives schemas and can request local dispatch, but AgentProvenance remains the
+trusted side of the boundary: it queries the local evidence store, computes
+policy verdicts, and never lets the model write raw telemetry, signatures, or
+provenance graph facts.
 
 ## Graph Commands
 

--- a/internal/aitools/aitools.go
+++ b/internal/aitools/aitools.go
@@ -1,0 +1,216 @@
+// Package aitools exposes AgentProvenance's read surface (and the inline policy
+// gate) as AI-callable tools. It is the single source the provider adapters
+// (Anthropic tool-use, OpenAI function-calling, generic/MCP) are generated from,
+// plus a dispatcher that executes a tool against the local store / policy engine.
+//
+// Trust boundary (see docs/ai-access.md): these tools let a model QUERY the
+// verifiable graph and pre-flight a proposed action; they never let the model
+// fabricate system events or signatures. The gate's verdict is computed by the
+// trusted policy engine, not the model.
+package aitools
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/byteyellow/agentprovenance/internal/provenance"
+	securitymodel "github.com/byteyellow/agentprovenance/internal/security"
+	"github.com/byteyellow/agentprovenance/internal/signals"
+	"github.com/byteyellow/agentprovenance/internal/telemetry"
+)
+
+// Tool is one AI-callable operation.
+type Tool struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+	Run         func(db *sql.DB, input map[string]any) (any, error)
+}
+
+// Catalog is the canonical AI tool set. Read tools query the verifiable graph;
+// evaluate_action is the inline pre-flight gate.
+func Catalog() []Tool {
+	return []Tool{
+		{
+			Name:        "verify_run",
+			Description: "Verify a run's evidence chain (object hashes, parent links, policy->risk->response->signal integrity). Returns status ok|failed with any issues.",
+			InputSchema: objSchema(map[string]any{"run": strProp("run id to verify")}, "run"),
+			Run: func(db *sql.DB, in map[string]any) (any, error) {
+				return provenance.Verify(db, strArg(in, "run"))
+			},
+		},
+		{
+			Name:        "get_signals",
+			Description: "List the unified signals (behavior/cost/quality/security) attached to a run's causality graph.",
+			InputSchema: objSchema(map[string]any{"run": strProp("run id")}, "run"),
+			Run: func(db *sql.DB, in map[string]any) (any, error) {
+				return signals.Export(db, strArg(in, "run"))
+			},
+		},
+		{
+			Name:        "list_risks",
+			Description: "List the security risk signals (metadata-IP, private-CIDR, secret-path, etc.) raised for a run, with recommended actions.",
+			InputSchema: objSchema(map[string]any{"run": strProp("run id")}, "run"),
+			Run: func(db *sql.DB, in map[string]any) (any, error) {
+				return securitymodel.BuildRiskSignalsReport(db, strArg(in, "run"))
+			},
+		},
+		{
+			Name:        "list_events",
+			Description: "List runtime telemetry events for a run (paged), optionally filtered by event type.",
+			InputSchema: objSchema(map[string]any{
+				"run":   strProp("run id"),
+				"type":  strProp("optional event_type filter, e.g. execve, metadata_ip"),
+				"limit": map[string]any{"type": "integer", "description": "max events (default 50)"},
+			}, "run"),
+			Run: func(db *sql.DB, in map[string]any) (any, error) {
+				return telemetry.ListEventsPage(db, telemetry.ListOptions{
+					Filter: telemetry.Filter{RunID: strArg(in, "run"), Type: strArg(in, "type")},
+					Limit:  intArg(in, "limit", 50),
+				})
+			},
+		},
+		{
+			Name:        "get_timeline",
+			Description: "Get the merged application-context + runtime-telemetry timeline for a run.",
+			InputSchema: objSchema(map[string]any{
+				"run":  strProp("run id"),
+				"view": map[string]any{"type": "string", "enum": []string{"table", "causality"}, "description": "timeline view"},
+			}, "run"),
+			Run: func(db *sql.DB, in map[string]any) (any, error) {
+				return provenance.BuildTimeline(db, provenance.TimelineOptions{RunID: strArg(in, "run"), View: strArg(in, "view")})
+			},
+		},
+		{
+			Name:        "evaluate_action",
+			Description: "Pre-flight gate: evaluate a PROPOSED agent action against the security policy WITHOUT executing it. Returns a verdict (allow|deny|quarantine|kill) computed by the trusted engine. Call before running a tool/command/connection.",
+			InputSchema: objSchema(map[string]any{
+				"event_type": strProp("one of: execve, network_connect, file_write, file_open"),
+				"command":    strProp("the command line for execve actions"),
+				"dst_ip":     strProp("destination IP for network_connect actions"),
+				"path":       strProp("file path for file actions"),
+			}, "event_type"),
+			Run: func(_ *sql.DB, in map[string]any) (any, error) {
+				return evaluateAction(in), nil
+			},
+		},
+	}
+}
+
+// evaluateAction runs a proposed action through the default policy engine with
+// no side effects (no DB write) -- the inline gate.
+func evaluateAction(in map[string]any) map[string]any {
+	ev := securitymodel.Event{
+		Source:    "ai_gate",
+		EventType: strArg(in, "event_type"),
+		DstIP:     strArg(in, "dst_ip"),
+		Path:      strArg(in, "path"),
+		Args:      strSliceArg(in, "args"),
+	}
+	if cmd := strArg(in, "command"); cmd != "" && len(ev.Args) == 0 {
+		ev.Args = strings.Fields(cmd)
+	}
+	d := securitymodel.DefaultEngine().Evaluate(ev)
+	return map[string]any{
+		"schema_version": "agentprovenance.ai_gate/v1",
+		"decision":       d.Decision,
+		"reason":         d.Reason,
+		"rule_id":        d.RuleID,
+		"allow":          d.Decision == "allow",
+	}
+}
+
+// Dispatch executes a named tool with the given input.
+func Dispatch(db *sql.DB, name string, input map[string]any) (any, error) {
+	for _, t := range Catalog() {
+		if t.Name == name {
+			return t.Run(db, input)
+		}
+	}
+	return nil, fmt.Errorf("unknown ai tool %q", name)
+}
+
+// AnthropicTools renders the catalog as Anthropic tool-use definitions.
+func AnthropicTools() []map[string]any {
+	out := make([]map[string]any, 0, len(Catalog()))
+	for _, t := range Catalog() {
+		out = append(out, map[string]any{
+			"name":         t.Name,
+			"description":  t.Description,
+			"input_schema": t.InputSchema,
+		})
+	}
+	return out
+}
+
+// OpenAITools renders the catalog as OpenAI function-calling definitions.
+func OpenAITools() []map[string]any {
+	out := make([]map[string]any, 0, len(Catalog()))
+	for _, t := range Catalog() {
+		out = append(out, map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        t.Name,
+				"description": t.Description,
+				"parameters":  t.InputSchema,
+			},
+		})
+	}
+	return out
+}
+
+// GenericTools renders a provider-neutral catalog.
+func GenericTools() []map[string]any {
+	out := make([]map[string]any, 0, len(Catalog()))
+	for _, t := range Catalog() {
+		out = append(out, map[string]any{
+			"name":         t.Name,
+			"description":  t.Description,
+			"input_schema": t.InputSchema,
+		})
+	}
+	return out
+}
+
+func objSchema(props map[string]any, required ...string) map[string]any {
+	s := map[string]any{"type": "object", "properties": props}
+	if len(required) > 0 {
+		s["required"] = required
+	}
+	return s
+}
+
+func strProp(desc string) map[string]any {
+	return map[string]any{"type": "string", "description": desc}
+}
+
+func strArg(in map[string]any, key string) string {
+	s, _ := in[key].(string)
+	return strings.TrimSpace(s)
+}
+
+func intArg(in map[string]any, key string, def int) int {
+	switch v := in[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	default:
+		return def
+	}
+}
+
+func strSliceArg(in map[string]any, key string) []string {
+	items, ok := in[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok && strings.TrimSpace(s) != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/aitools/aitools.go
+++ b/internal/aitools/aitools.go
@@ -88,8 +88,13 @@ func Catalog() []Tool {
 			InputSchema: objSchema(map[string]any{
 				"event_type": strProp("one of: execve, network_connect, file_write, file_open"),
 				"command":    strProp("the command line for execve actions"),
-				"dst_ip":     strProp("destination IP for network_connect actions"),
-				"path":       strProp("file path for file actions"),
+				"args": map[string]any{
+					"type":        "array",
+					"description": "structured argv for execve actions; preferred when the caller already has tokenized arguments",
+					"items":       map[string]any{"type": "string"},
+				},
+				"dst_ip": strProp("destination IP for network_connect actions"),
+				"path":   strProp("file path for file actions"),
 			}, "event_type"),
 			Run: func(_ *sql.DB, in map[string]any) (any, error) {
 				return evaluateAction(in), nil

--- a/internal/aitools/aitools_test.go
+++ b/internal/aitools/aitools_test.go
@@ -1,0 +1,71 @@
+package aitools
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/byteyellow/agentprovenance/internal/store"
+)
+
+func TestCatalogAndProviderShapes(t *testing.T) {
+	if len(Catalog()) < 5 {
+		t.Fatalf("catalog too small: %d", len(Catalog()))
+	}
+	for _, tool := range Catalog() {
+		if tool.Name == "" || tool.Description == "" || tool.InputSchema == nil || tool.Run == nil {
+			t.Fatalf("incomplete tool: %+v", tool.Name)
+		}
+	}
+	a := AnthropicTools()
+	if len(a) != len(Catalog()) || a[0]["input_schema"] == nil {
+		t.Fatalf("anthropic shape wrong: %+v", a[0])
+	}
+	o := OpenAITools()
+	if o[0]["type"] != "function" || o[0]["function"] == nil {
+		t.Fatalf("openai shape wrong: %+v", o[0])
+	}
+}
+
+func TestEvaluateActionGate(t *testing.T) {
+	// metadata IP -> quarantine; benign exec -> allow. No DB needed.
+	q, err := Dispatch(nil, "evaluate_action", map[string]any{"event_type": "network_connect", "dst_ip": "169.254.169.254"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := q.(map[string]any)
+	if m["decision"] != "quarantine" || m["allow"] != false {
+		t.Fatalf("metadata IP should quarantine, got %+v", m)
+	}
+	a, _ := Dispatch(nil, "evaluate_action", map[string]any{"event_type": "execve", "command": "ls -la"})
+	if a.(map[string]any)["allow"] != true {
+		t.Fatalf("benign exec should allow, got %+v", a)
+	}
+	// secret path in a proposed command -> kill.
+	s, _ := Dispatch(nil, "evaluate_action", map[string]any{"event_type": "file_write", "path": "/home/agent/.aws/credentials"})
+	if s.(map[string]any)["decision"] != "kill" {
+		t.Fatalf("credentials path should kill, got %+v", s)
+	}
+}
+
+func TestDispatchReadToolAgainstStore(t *testing.T) {
+	root := t.TempDir()
+	paths, err := store.Init(filepath.Join(root, ".agentprov"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	// verify_run on an empty run should still return a structured result.
+	if _, err := Dispatch(db, "verify_run", map[string]any{"run": "nope"}); err != nil {
+		t.Fatalf("verify_run dispatch: %v", err)
+	}
+	if _, err := Dispatch(db, "get_signals", map[string]any{"run": "nope"}); err != nil {
+		t.Fatalf("get_signals dispatch: %v", err)
+	}
+	if _, err := Dispatch(db, "no_such_tool", nil); err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+}

--- a/internal/cli/ai_cmd.go
+++ b/internal/cli/ai_cmd.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/byteyellow/agentprovenance/internal/aitools"
+	"github.com/spf13/cobra"
+)
+
+// aiCmd exposes the AI-callable tool surface: `ai tools` emits provider tool
+// definitions, `ai call` dispatches one tool against the local store / policy
+// engine. See docs/ai-access.md.
+func aiCmd(dataDir *string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ai",
+		Short: "AI-callable tools over the verifiable provenance graph",
+	}
+	cmd.AddCommand(aiToolsCmd())
+	cmd.AddCommand(aiCallCmd(dataDir))
+	return cmd
+}
+
+func aiToolsCmd() *cobra.Command {
+	var provider string
+	cmd := &cobra.Command{
+		Use:   "tools",
+		Short: "emit AI tool definitions for a provider (generic|anthropic|openai)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var tools []map[string]any
+			switch provider {
+			case "", "generic":
+				tools = aitools.GenericTools()
+			case "anthropic":
+				tools = aitools.AnthropicTools()
+			case "openai":
+				tools = aitools.OpenAITools()
+			default:
+				return fmt.Errorf("unknown provider %q (want generic|anthropic|openai)", provider)
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(map[string]any{
+				"schema_version": "agentprovenance.ai_tools/v1",
+				"provider":       firstNonEmptyStr(provider, "generic"),
+				"tools":          tools,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&provider, "provider", "generic", "tool schema provider: generic, anthropic, or openai")
+	return cmd
+}
+
+func aiCallCmd(dataDir *string) *cobra.Command {
+	var input string
+	cmd := &cobra.Command{
+		Use:   "call <tool>",
+		Short: "dispatch one AI tool with a JSON --input",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parsed := map[string]any{}
+			if input != "" {
+				if err := json.Unmarshal([]byte(input), &parsed); err != nil {
+					return fmt.Errorf("invalid --input JSON: %w", err)
+				}
+			}
+			db, cleanup, err := openLocalDB(*dataDir)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			result, err := aitools.Dispatch(db, args[0], parsed)
+			if err != nil {
+				return err
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(result)
+		},
+	}
+	cmd.Flags().StringVar(&input, "input", "", "tool input as a JSON object")
+	return cmd
+}
+
+func firstNonEmptyStr(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,6 +43,7 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(securityCmd(&dataDir, &daemonURL))
 	root.AddCommand(signalCmd(&dataDir, &daemonURL))
 	root.AddCommand(signalsCmd(&dataDir))
+	root.AddCommand(aiCmd(&dataDir))
 	root.AddCommand(complianceCmd(&dataDir))
 	root.AddCommand(gcCmd(&dataDir))
 	root.AddCommand(baselineCmd(&dataDir))


### PR DESCRIPTION
## Summary
- expose `evaluate_action.args` in the AI tool schema so callers can pass structured argv
- document `agentprov ai tools` / `agentprov ai call` in README
- clarify that AI-callable tools are an evidence/query and trusted policy-gate surface, not an LLM gateway or telemetry write path

## Validation
- `go test ./...`
- `./scripts/accept_phase1.sh`
- `go run ./cmd/agentprov ai tools --provider openai | rg '"args"|"evaluate_action"|"items"' -n`
