### PR TITLE
feat: MCP server + context-write AI tools

### DIFF
--- a/docs/ai-access.md
+++ b/docs/ai-access.md
@@ -39,8 +39,14 @@ returning a versioned JSON envelope. This is the canonical list adapters expose.
 | explain_correlations | GET /v1/telemetry/correlations?run= | telemetry correlations --run --json | agentprovenance.telemetry_correlations/v1 |
 | health | GET /v1/health | (daemon) | agentprovenance.daemon_health/v1 |
 
-Context-write surface (phase 2): bind_scope (POST /v1/telemetry/bind),
-record (POST /v1/record). Gate (phase 3): evaluate_action.
+Context-write surface (phase 2, **shipped** as AI tools): `bind_scope` (register a
+ToolCallScope binding, over `correlation.RecordBinding`) and `record_tool_call`
+(anchor an app-asserted tool call). Both write only app-side context — forced
+`binding_source=ai_asserted` / `status=asserted`, no execution, no system events —
+so they cannot fabricate independent (kernel_correlated) evidence. The daemon
+analogues remain `POST /v1/telemetry/bind` and `POST /v1/record` (the latter also
+executes; the AI tool deliberately does not). Gate (phase 3, shipped):
+`evaluate_action`.
 
 ## 2. Adapters (one contract, many surfaces)
 
@@ -49,9 +55,30 @@ record (POST /v1/record). Gate (phase 3): evaluate_action.
 | CLI-as-tool | a stable `--json` contract + a tool manual prompt | ~0 (exists) | code-execution agents (Claude Code, etc.) |
 | OpenAPI spec | one openapi.yaml over the read endpoints | low | GPT Actions, any OpenAPI tool importer |
 | Provider tool-schemas | Anthropic tool-use / OpenAI function defs + dispatcher | low-med | direct tool-calling apps |
-| MCP server | an MCP server wrapping the read surface | med | MCP clients |
+| MCP server | stdio MCP server wrapping the read surface + gate (`agentprov ai mcp`) — **shipped** | med | MCP clients |
 | SDK framework tools | LangChain/LlamaIndex/CrewAI/Agents-SDK wrappers over the Python SDK | med | agents built in those frameworks |
 | A2A agent-card | expose AgentProvenance as a delegatable agent | med (frontier) | agent-to-agent delegation |
+
+### 2.1 MCP server (`agentprov ai mcp`)
+
+A stdio MCP server (spec revision `2025-06-18`, JSON-RPC 2.0 over stdin/stdout)
+generated from the same `internal/aitools.Catalog()` / `Dispatch` as the provider
+tool-schemas and `ai call` — so MCP clients see exactly the eight tools (five read,
+the `evaluate_action` gate, and the `bind_scope` / `record_tool_call` context-write
+tools) with no separate contract to drift. The two write tools carry
+`annotations.readOnlyHint=false`; everything else is hinted read-only. Only
+JSON-RPC is written to stdout; diagnostics stay on stderr. Tool results carry the
+serialized JSON in a `text` content block, with object results also surfaced as
+`structuredContent`. Wire it into a client, e.g.:
+
+```json
+{ "mcpServers": { "agentprovenance": { "command": "agentprov", "args": ["ai", "mcp"] } } }
+```
+
+`initialize` → `tools/list` → `tools/call` is the full handshake; the trust
+boundary in §0 is inherited unchanged (no fabrication of system events/signatures;
+the gate verdict is the engine's, not the model's). Implementation:
+`internal/mcpserver`.
 
 ## 3. The differentiated one: the inline gate (push, not pull)
 
@@ -64,11 +91,11 @@ verifiable evidence, which a plain query tool cannot provide.
 
 ## 4. Roadmap
 
-1. **Read adapters** (now): CLI tool manual + OpenAPI spec, then provider
-   tool-schemas, then an MCP server -- all over section 1.
-2. **Context-write tools**: bind_scope / record_tool_call so an agent registers
-   its own ToolCallScope (zero-instrumentation correlation), within the trust
-   boundary.
+1. **Read adapters** (done): CLI tool manual + OpenAPI spec, provider
+   tool-schemas, and the stdio MCP server (§2.1) -- all over section 1.
+2. **Context-write tools** (done): bind_scope / record_tool_call so an agent
+   registers its own ToolCallScope (zero-instrumentation correlation), within the
+   trust boundary — app-asserted only, never forging system evidence.
 3. **Inline gate**: evaluate_action over the policy/correlation engine.
 4. **Analysis direction** (optional): an observer-LLM step over the SIGNED graph
    (semantic risk explanation on tamper-evident evidence).

--- a/internal/aitools/aitools.go
+++ b/internal/aitools/aitools.go
@@ -1,19 +1,27 @@
-// Package aitools exposes AgentProvenance's read surface (and the inline policy
-// gate) as AI-callable tools. It is the single source the provider adapters
-// (Anthropic tool-use, OpenAI function-calling, generic/MCP) are generated from,
-// plus a dispatcher that executes a tool against the local store / policy engine.
+// Package aitools exposes AgentProvenance's read surface, the inline policy
+// gate, and the context-write surface as AI-callable tools. It is the single
+// source the provider adapters (Anthropic tool-use, OpenAI function-calling,
+// generic/MCP) are generated from, plus a dispatcher that executes a tool
+// against the local store / policy engine.
 //
-// Trust boundary (see docs/ai-access.md): these tools let a model QUERY the
-// verifiable graph and pre-flight a proposed action; they never let the model
-// fabricate system events or signatures. The gate's verdict is computed by the
-// trusted policy engine, not the model.
+// Trust boundary (see docs/ai-access.md §0): these tools let a model QUERY the
+// verifiable graph, pre-flight a proposed action, and ASSERT its own app-side
+// context (bind_scope / record_tool_call). They never let the model fabricate
+// system events or signatures: context-write rows are recorded as ai_asserted
+// and execute nothing, and the gate's verdict is computed by the trusted policy
+// engine, not the model. Tool.Writes marks the mutating context-write tools.
 package aitools
 
 import (
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/byteyellow/agentprovenance/internal/correlation"
+	"github.com/byteyellow/agentprovenance/internal/ids"
 	"github.com/byteyellow/agentprovenance/internal/provenance"
 	securitymodel "github.com/byteyellow/agentprovenance/internal/security"
 	"github.com/byteyellow/agentprovenance/internal/signals"
@@ -25,7 +33,11 @@ type Tool struct {
 	Name        string
 	Description string
 	InputSchema map[string]any
-	Run         func(db *sql.DB, input map[string]any) (any, error)
+	// Writes is true for tools that mutate the local store (the context-write
+	// surface). Read tools and the no-side-effect gate leave it false. Adapters
+	// use this to advertise read-only-ness (e.g. the MCP readOnlyHint).
+	Writes bool
+	Run    func(db *sql.DB, input map[string]any) (any, error)
 }
 
 // Catalog is the canonical AI tool set. Read tools query the verifiable graph;
@@ -100,7 +112,114 @@ func Catalog() []Tool {
 				return evaluateAction(in), nil
 			},
 		},
+		{
+			Name:        "bind_scope",
+			Description: "Register a ToolCallScope binding: assert that this run+tool_call ran as the given OS process/container/cgroup so independent system telemetry can later be correlated to it (zero-instrumentation). This is APP-ASSERTED context only -- the binding is recorded with source ai_asserted and cannot fabricate system events or signatures; it merely provides a join key the trusted correlation engine may use when real kernel events arrive.",
+			InputSchema: objSchema(map[string]any{
+				"run":          strProp("run id this scope belongs to"),
+				"tool_call":    strProp("tool_call id to bind"),
+				"process_id":   strProp("optional AgentProvenance process id for this scope"),
+				"container_id": strProp("optional runtime-observable container id"),
+				"cgroup_id":    strProp("optional runtime-observable cgroup id"),
+				"pid":          intProp("optional OS process id"),
+				"root_pid":     intProp("optional root OS process id for the scope"),
+				"started_at":   strProp("optional RFC3339 start; defaults to now"),
+				"ended_at":     strProp("optional RFC3339 end; empty leaves the scope open"),
+			}, "run", "tool_call"),
+			Writes: true,
+			Run:    bindScope,
+		},
+		{
+			Name:        "record_tool_call",
+			Description: "Record an APP-ASSERTED tool call: anchor that this run invoked the named tool/command, returning a tool_call id you can then bind_scope to a process. This does NOT execute anything and does NOT create system evidence; the row is stored with status/policy_decision 'asserted' so consumers can tell it apart from a gate-decided or kernel-observed call.",
+			InputSchema: objSchema(map[string]any{
+				"run":       strProp("run id this tool call belongs to"),
+				"command":   strProp("the tool name / command line the agent is asserting it invoked"),
+				"tool_call": strProp("optional tool_call id to use; generated when omitted"),
+			}, "run", "command"),
+			Writes: true,
+			Run:    recordToolCall,
+		},
 	}
+}
+
+// assertedStatus marks rows written by the context-write tools as agent
+// assertions, distinct from 'running'/'completed' (gate/recorder lifecycle) and
+// from any kernel-observed state. policy_decision is set to the same value so a
+// consumer never mistakes an asserted call for one the trusted gate allowed.
+const assertedStatus = "asserted"
+
+// recordToolCall inserts a minimal, parent-less tool_calls anchor. It executes
+// nothing (vs. the `record` recorder, which spawns the command) and writes no
+// telemetry events -- so it stays strictly inside the app-context trust boundary.
+// verify_run/get_timeline tolerate the empty rollout/attempt/session links.
+func recordToolCall(db *sql.DB, in map[string]any) (any, error) {
+	runID := strArg(in, "run")
+	command := strArg(in, "command")
+	if runID == "" || command == "" {
+		return nil, fmt.Errorf("record_tool_call requires run and command")
+	}
+	toolCallID := strArg(in, "tool_call")
+	if toolCallID == "" {
+		toolCallID = ids.New("tool")
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	sum := sha256.Sum256([]byte(command))
+	if _, err := db.Exec(`INSERT INTO tool_calls
+		(id, run_id, command, args_hash, status, policy_decision, created_at, started_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		toolCallID, runID, command, hex.EncodeToString(sum[:]), assertedStatus, assertedStatus, now, now); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"schema_version": "agentprovenance.ai_record_tool_call/v1",
+		"tool_call":      toolCallID,
+		"run":            runID,
+		"status":         assertedStatus,
+	}, nil
+}
+
+// aiBindingSource is the binding_source forced on every bind_scope write. It is
+// NOT caller-controllable: an agent-asserted scope must never masquerade as the
+// trusted control plane (RecordBinding's default) -- this label is the only
+// audit trail that the attribution was agent-asserted. See docs/ai-access.md §0.
+const aiBindingSource = "ai_asserted"
+
+// bindScope records an app-asserted ToolCallScope binding. The model supplies
+// the observable identifiers (pid/container/cgroup) that let real kernel events
+// resolve to this tool call, but it cannot set the binding_source or confidence:
+// the join only yields independent (kernel_correlated) evidence when a genuine
+// system event matches, never from this assertion alone.
+func bindScope(db *sql.DB, in map[string]any) (any, error) {
+	runID := strArg(in, "run")
+	toolCallID := strArg(in, "tool_call")
+	if runID == "" || toolCallID == "" {
+		return nil, fmt.Errorf("bind_scope requires run and tool_call")
+	}
+	id, err := correlation.RecordBinding(db, correlation.Binding{
+		RunID:         runID,
+		ToolCallID:    toolCallID,
+		ProcessID:     strArg(in, "process_id"),
+		ContainerID:   strArg(in, "container_id"),
+		CgroupID:      strArg(in, "cgroup_id"),
+		PID:           int64Arg(in, "pid"),
+		RootPID:       int64Arg(in, "root_pid"),
+		StartedAt:     strArg(in, "started_at"),
+		EndedAt:       strArg(in, "ended_at"),
+		BindingSource: aiBindingSource, // forced; overrides any caller value
+		// Confidence left zero -> RecordBinding defaults it to 1.0 (binding
+		// precision); the matching method's confidence governs correlation.
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"schema_version": "agentprovenance.ai_bind/v1",
+		"binding_id":     id,
+		"binding_source": aiBindingSource,
+		"run":            runID,
+		"tool_call":      toolCallID,
+	}, nil
 }
 
 // evaluateAction runs a proposed action through the default policy engine with
@@ -190,6 +309,10 @@ func strProp(desc string) map[string]any {
 	return map[string]any{"type": "string", "description": desc}
 }
 
+func intProp(desc string) map[string]any {
+	return map[string]any{"type": "integer", "description": desc}
+}
+
 func strArg(in map[string]any, key string) string {
 	s, _ := in[key].(string)
 	return strings.TrimSpace(s)
@@ -203,6 +326,19 @@ func intArg(in map[string]any, key string, def int) int {
 		return v
 	default:
 		return def
+	}
+}
+
+func int64Arg(in map[string]any, key string) int64 {
+	switch v := in[key].(type) {
+	case float64:
+		return int64(v)
+	case int:
+		return int64(v)
+	case int64:
+		return v
+	default:
+		return 0
 	}
 }
 

--- a/internal/aitools/aitools_test.go
+++ b/internal/aitools/aitools_test.go
@@ -1,11 +1,27 @@
 package aitools
 
 import (
+	"database/sql"
 	"path/filepath"
 	"testing"
 
+	"github.com/byteyellow/agentprovenance/internal/correlation"
 	"github.com/byteyellow/agentprovenance/internal/store"
 )
+
+func openTestStore(t *testing.T) *sql.DB {
+	t.Helper()
+	paths, err := store.Init(filepath.Join(t.TempDir(), ".agentprov"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
 
 func TestCatalogAndProviderShapes(t *testing.T) {
 	if len(Catalog()) < 5 {
@@ -67,5 +83,72 @@ func TestDispatchReadToolAgainstStore(t *testing.T) {
 	}
 	if _, err := Dispatch(db, "no_such_tool", nil); err == nil {
 		t.Fatal("expected error for unknown tool")
+	}
+}
+
+func TestContextWriteToolsAssertWithinTrustBoundary(t *testing.T) {
+	db := openTestStore(t)
+
+	// record_tool_call anchors an app-asserted call and returns its id.
+	rec, err := Dispatch(db, "record_tool_call", map[string]any{"run": "run-1", "command": "curl https://api.example.com"})
+	if err != nil {
+		t.Fatalf("record_tool_call: %v", err)
+	}
+	recMap := rec.(map[string]any)
+	toolCall, _ := recMap["tool_call"].(string)
+	if toolCall == "" {
+		t.Fatalf("record_tool_call returned no tool_call id: %+v", recMap)
+	}
+	if recMap["status"] != assertedStatus {
+		t.Errorf("status = %v, want %q so consumers can tell it from a gate/kernel call", recMap["status"], assertedStatus)
+	}
+
+	// bind_scope links the asserted call to an observable process scope.
+	out, err := Dispatch(db, "bind_scope", map[string]any{
+		"run":          "run-1",
+		"tool_call":    toolCall,
+		"pid":          float64(4242), // JSON numbers arrive as float64
+		"container_id": "agentprov-abc",
+		// A caller trying to forge trusted provenance: must be overridden.
+		"binding_source": "kernel",
+	})
+	if err != nil {
+		t.Fatalf("bind_scope: %v", err)
+	}
+	if out.(map[string]any)["binding_source"] != aiBindingSource {
+		t.Fatalf("bind_scope must force source to %q, got %+v", aiBindingSource, out)
+	}
+
+	// The persisted binding must carry the honest ai_asserted source (not the
+	// caller's "kernel"), with the observable identifiers preserved for join.
+	bindings, err := correlation.ListBindings(db, correlation.BindingFilter{RunID: "run-1", ToolCallID: toolCall})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("want 1 binding, got %d", len(bindings))
+	}
+	b := bindings[0]
+	if b.BindingSource != aiBindingSource {
+		t.Errorf("persisted binding_source = %q, want %q (no masquerading as control plane/kernel)", b.BindingSource, aiBindingSource)
+	}
+	if b.PID != 4242 || b.ContainerID != "agentprov-abc" {
+		t.Errorf("observable identifiers not preserved: %+v", b)
+	}
+
+	// Required-arg guards.
+	if _, err := Dispatch(db, "bind_scope", map[string]any{"run": "run-1"}); err == nil {
+		t.Error("bind_scope should require tool_call")
+	}
+	if _, err := Dispatch(db, "record_tool_call", map[string]any{"run": "run-1"}); err == nil {
+		t.Error("record_tool_call should require command")
+	}
+
+	// The orphan anchor must not break the read/verify surface.
+	if _, err := Dispatch(db, "verify_run", map[string]any{"run": "run-1"}); err != nil {
+		t.Errorf("verify_run broke on app-asserted tool_call: %v", err)
+	}
+	if _, err := Dispatch(db, "get_timeline", map[string]any{"run": "run-1"}); err != nil {
+		t.Errorf("get_timeline broke on app-asserted tool_call: %v", err)
 	}
 }

--- a/internal/cli/ai_cmd.go
+++ b/internal/cli/ai_cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/byteyellow/agentprovenance/internal/aitools"
+	"github.com/byteyellow/agentprovenance/internal/mcpserver"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +19,31 @@ func aiCmd(dataDir *string) *cobra.Command {
 	}
 	cmd.AddCommand(aiToolsCmd())
 	cmd.AddCommand(aiCallCmd(dataDir))
+	cmd.AddCommand(aiMCPCmd(dataDir))
 	return cmd
+}
+
+// aiMCPCmd runs a stdio MCP server over the same aitools catalog/dispatcher, so
+// MCP clients get the read surface + inline gate. Only JSON-RPC goes to stdout;
+// cobra writes its own diagnostics to stderr.
+func aiMCPCmd(dataDir *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "mcp",
+		Short: "run a stdio MCP server exposing the AI tool surface (JSON-RPC 2.0)",
+		Long: "Speaks the Model Context Protocol (spec 2025-06-18) over stdin/stdout so MCP " +
+			"clients (Claude Desktop, the mcp inspector) can query the verifiable provenance " +
+			"graph and pre-flight proposed actions through the trusted policy gate. The tool set " +
+			"is the same one served by `ai tools`/`ai call`. Only JSON-RPC is written to stdout.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			db, cleanup, err := openLocalDB(*dataDir)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			return mcpserver.Serve(db, cmd.InOrStdin(), cmd.OutOrStdout())
+		},
+	}
 }
 
 func aiToolsCmd() *cobra.Command {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -1,0 +1,241 @@
+// Package mcpserver exposes AgentProvenance's AI tool surface over the Model
+// Context Protocol (MCP, spec revision 2025-06-18) as a stdio JSON-RPC 2.0
+// server. It is a thin transport over internal/aitools: the tool catalog and
+// dispatcher are the single source of truth, so an MCP client (Claude Desktop,
+// the mcp inspector, etc.) sees exactly the same read surface + inline policy
+// gate as the `agentprov ai` CLI and the provider adapters.
+//
+// Trust boundary is inherited from aitools (see docs/ai-access.md): tools let a
+// model QUERY the verifiable graph and pre-flight a proposed action; the gate
+// verdict is computed by the trusted engine, never fabricated by the model.
+//
+// Wire framing is newline-delimited JSON (one JSON-RPC message per line). Only
+// JSON-RPC is written to the output stream -- callers must keep diagnostics on
+// stderr so the stdout channel stays clean for the client.
+package mcpserver
+
+import (
+	"bufio"
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/byteyellow/agentprovenance/internal/aitools"
+)
+
+// ProtocolVersion is the MCP spec revision this server implements. During the
+// initialize handshake we echo the client's requested version when it sends one
+// (maximizing client compatibility) and fall back to this otherwise.
+const ProtocolVersion = "2025-06-18"
+
+const (
+	serverName    = "agentprovenance"
+	serverVersion = "0.2.0"
+)
+
+// JSON-RPC 2.0 standard error codes.
+const (
+	codeParse          = -32700
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+)
+
+const instructions = "Query the verifiable AgentProvenance graph (verify_run, get_signals, " +
+	"list_risks, list_events, get_timeline) and pre-flight a PROPOSED agent action through the " +
+	"trusted policy gate (evaluate_action) before executing it. The gate verdict is computed by " +
+	"the engine, not the model; these tools cannot fabricate system events or signatures."
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+// Serve runs the MCP stdio loop: it reads newline-delimited JSON-RPC messages
+// from r and writes responses to w until r reaches EOF (a clean shutdown). It
+// returns a non-nil error only on an unrecoverable transport failure.
+func Serve(db *sql.DB, r io.Reader, w io.Writer) error {
+	br := bufio.NewReaderSize(r, 1<<20)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	for {
+		line, readErr := br.ReadBytes('\n')
+		if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
+			if err := handleLine(db, trimmed, enc); err != nil {
+				return err
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return nil
+			}
+			return readErr
+		}
+	}
+}
+
+func handleLine(db *sql.DB, line []byte, enc *json.Encoder) error {
+	var req rpcRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		// Per JSON-RPC, a parse error is answered with a null id.
+		return enc.Encode(rpcResponse{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage("null"),
+			Error:   &rpcError{Code: codeParse, Message: "parse error"},
+		})
+	}
+	resp, respond := dispatch(db, req)
+	if !respond {
+		return nil
+	}
+	return enc.Encode(resp)
+}
+
+// dispatch routes one request. The bool is false for notifications (id absent or
+// null), which must not produce a response.
+func dispatch(db *sql.DB, req rpcRequest) (rpcResponse, bool) {
+	if isNotification(req.ID) {
+		return rpcResponse{}, false
+	}
+	resp := rpcResponse{JSONRPC: "2.0", ID: req.ID}
+	switch req.Method {
+	case "initialize":
+		resp.Result = initializeResult(req.Params)
+	case "ping":
+		resp.Result = map[string]any{}
+	case "tools/list":
+		resp.Result = map[string]any{"tools": toolDefs()}
+	case "tools/call":
+		result, rerr := callTool(db, req.Params)
+		if rerr != nil {
+			resp.Error = rerr
+		} else {
+			resp.Result = result
+		}
+	default:
+		resp.Error = &rpcError{Code: codeMethodNotFound, Message: fmt.Sprintf("method not found: %s", req.Method)}
+	}
+	return resp, true
+}
+
+func isNotification(id json.RawMessage) bool {
+	s := strings.TrimSpace(string(id))
+	return s == "" || s == "null"
+}
+
+func initializeResult(params json.RawMessage) map[string]any {
+	version := ProtocolVersion
+	if len(params) > 0 {
+		var p struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if json.Unmarshal(params, &p) == nil && p.ProtocolVersion != "" {
+			version = p.ProtocolVersion
+		}
+	}
+	return map[string]any{
+		"protocolVersion": version,
+		"capabilities":    map[string]any{"tools": map[string]any{"listChanged": false}},
+		"serverInfo":      map[string]any{"name": serverName, "version": serverVersion},
+		"instructions":    instructions,
+	}
+}
+
+// toolDefs renders aitools.Catalog() as MCP tool definitions. MCP uses the
+// camelCase inputSchema key (vs. the provider adapters' input_schema).
+func toolDefs() []map[string]any {
+	cat := aitools.Catalog()
+	out := make([]map[string]any, 0, len(cat))
+	for _, t := range cat {
+		out = append(out, map[string]any{
+			"name":        t.Name,
+			"description": t.Description,
+			"inputSchema": t.InputSchema,
+			// readOnlyHint surfaces the trust boundary to clients: the read
+			// surface + gate touch nothing; the context-write tools assert
+			// app-side context (see docs/ai-access.md §0).
+			"annotations": map[string]any{"readOnlyHint": !t.Writes},
+		})
+	}
+	return out
+}
+
+func callTool(db *sql.DB, params json.RawMessage) (map[string]any, *rpcError) {
+	var p struct {
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments"`
+	}
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, &rpcError{Code: codeInvalidParams, Message: fmt.Sprintf("invalid params: %v", err)}
+		}
+	}
+	if p.Name == "" {
+		return nil, &rpcError{Code: codeInvalidParams, Message: "missing tool name"}
+	}
+	if p.Arguments == nil {
+		p.Arguments = map[string]any{}
+	}
+	result, err := aitools.Dispatch(db, p.Name, p.Arguments)
+	if err != nil {
+		// An unknown tool is a protocol error (the method does not exist); a tool
+		// that ran but failed is reported in-band with isError per the MCP spec.
+		if strings.HasPrefix(err.Error(), "unknown ai tool") {
+			return nil, &rpcError{Code: codeMethodNotFound, Message: err.Error()}
+		}
+		return toolResult(map[string]any{"error": err.Error()}, true), nil
+	}
+	return toolResult(result, false), nil
+}
+
+// toolResult wraps a dispatch payload as an MCP CallToolResult: the serialized
+// JSON always goes in a text content block, and object payloads are additionally
+// surfaced as structuredContent (per the spec's backwards-compat guidance).
+func toolResult(payload any, isError bool) map[string]any {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		raw = []byte(fmt.Sprintf("%q", err.Error()))
+	}
+	var indented bytes.Buffer
+	if json.Indent(&indented, raw, "", "  ") != nil {
+		indented.Write(raw)
+	}
+	res := map[string]any{
+		"content": []map[string]any{{"type": "text", "text": indented.String()}},
+		"isError": isError,
+	}
+	if obj := asObject(raw); obj != nil {
+		res["structuredContent"] = obj
+	}
+	return res
+}
+
+func asObject(raw []byte) map[string]any {
+	t := bytes.TrimSpace(raw)
+	if len(t) == 0 || t[0] != '{' {
+		return nil
+	}
+	var obj map[string]any
+	if json.Unmarshal(t, &obj) != nil {
+		return nil
+	}
+	return obj
+}

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1,0 +1,191 @@
+package mcpserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/byteyellow/agentprovenance/internal/aitools"
+)
+
+// run feeds newline-delimited JSON-RPC requests through Serve and returns the
+// decoded response objects (notifications produce no line, so the count may be
+// smaller than len(requests)). A nil *sql.DB is fine for the handshake, the
+// inline gate, and the error paths -- none of them touch the store.
+func run(t *testing.T, requests ...string) []map[string]any {
+	t.Helper()
+	in := strings.NewReader(strings.Join(requests, "\n") + "\n")
+	var out bytes.Buffer
+	if err := Serve(nil, in, &out); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	var resps []map[string]any
+	dec := json.NewDecoder(&out)
+	for dec.More() {
+		var m map[string]any
+		if err := dec.Decode(&m); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		resps = append(resps, m)
+	}
+	return resps
+}
+
+func result(t *testing.T, resp map[string]any) map[string]any {
+	t.Helper()
+	if errObj, ok := resp["error"]; ok {
+		t.Fatalf("unexpected error response: %v", errObj)
+	}
+	res, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("response has no result object: %v", resp)
+	}
+	return res
+}
+
+func TestInitializeEchoesProtocolVersionAndAdvertisesTools(t *testing.T) {
+	resps := run(t, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}`)
+	if len(resps) != 1 {
+		t.Fatalf("want 1 response, got %d", len(resps))
+	}
+	res := result(t, resps[0])
+	if got := res["protocolVersion"]; got != "2025-03-26" {
+		t.Errorf("protocolVersion = %v, want echoed 2025-03-26", got)
+	}
+	caps, _ := res["capabilities"].(map[string]any)
+	if _, ok := caps["tools"]; !ok {
+		t.Errorf("capabilities missing tools: %v", caps)
+	}
+	info, _ := res["serverInfo"].(map[string]any)
+	if info["name"] != serverName {
+		t.Errorf("serverInfo.name = %v, want %s", info["name"], serverName)
+	}
+}
+
+func TestInitializeFallsBackToDefaultVersion(t *testing.T) {
+	resps := run(t, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	res := result(t, resps[0])
+	if got := res["protocolVersion"]; got != ProtocolVersion {
+		t.Errorf("protocolVersion = %v, want default %s", got, ProtocolVersion)
+	}
+}
+
+func TestToolsListMatchesCatalog(t *testing.T) {
+	resps := run(t, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	res := result(t, resps[0])
+	tools, ok := res["tools"].([]any)
+	if !ok {
+		t.Fatalf("tools is not an array: %v", res["tools"])
+	}
+	if len(tools) != len(aitools.Catalog()) {
+		t.Fatalf("tools/list returned %d tools, catalog has %d", len(tools), len(aitools.Catalog()))
+	}
+	got := map[string]bool{}
+	for _, raw := range tools {
+		tool := raw.(map[string]any)
+		name, _ := tool["name"].(string)
+		if name == "" {
+			t.Errorf("tool missing name: %v", tool)
+		}
+		if _, ok := tool["inputSchema"].(map[string]any); !ok {
+			t.Errorf("tool %q missing camelCase inputSchema: %v", name, tool)
+		}
+		if _, ok := tool["description"].(string); !ok {
+			t.Errorf("tool %q missing description", name)
+		}
+		got[name] = true
+	}
+	for _, want := range []string{"verify_run", "get_signals", "list_risks", "list_events", "get_timeline", "evaluate_action"} {
+		if !got[want] {
+			t.Errorf("tools/list missing %q", want)
+		}
+	}
+}
+
+func TestToolsCallEvaluateActionReturnsGateVerdict(t *testing.T) {
+	// 169.254.169.254 is the cloud metadata IP -> the policy gate must not allow it.
+	resps := run(t, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"evaluate_action","arguments":{"event_type":"network_connect","dst_ip":"169.254.169.254"}}}`)
+	res := result(t, resps[0])
+	if res["isError"] != false {
+		t.Errorf("isError = %v, want false (the gate ran successfully)", res["isError"])
+	}
+	structured, ok := res["structuredContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing structuredContent: %v", res)
+	}
+	if structured["decision"] == "allow" || structured["allow"] == true {
+		t.Errorf("metadata-IP connect should not be allowed, got %v", structured)
+	}
+	content, ok := res["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("missing content blocks: %v", res)
+	}
+	first := content[0].(map[string]any)
+	if first["type"] != "text" {
+		t.Errorf("content[0].type = %v, want text", first["type"])
+	}
+	if !strings.Contains(first["text"].(string), "decision") {
+		t.Errorf("content text should carry the serialized verdict, got %q", first["text"])
+	}
+}
+
+func TestNotificationProducesNoResponse(t *testing.T) {
+	resps := run(t,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":7,"method":"ping"}`,
+	)
+	if len(resps) != 1 {
+		t.Fatalf("want 1 response (notification is silent), got %d: %v", len(resps), resps)
+	}
+	if resps[0]["id"].(float64) != 7 {
+		t.Errorf("response id = %v, want the ping id 7", resps[0]["id"])
+	}
+}
+
+func TestUnknownMethodIsProtocolError(t *testing.T) {
+	resps := run(t, `{"jsonrpc":"2.0","id":8,"method":"resources/list"}`)
+	errObj, ok := resps[0]["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("want error response, got %v", resps[0])
+	}
+	if errObj["code"].(float64) != codeMethodNotFound {
+		t.Errorf("code = %v, want %d", errObj["code"], codeMethodNotFound)
+	}
+}
+
+func TestUnknownToolIsProtocolError(t *testing.T) {
+	resps := run(t, `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"no_such_tool","arguments":{}}}`)
+	errObj, ok := resps[0]["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("want error response for unknown tool, got %v", resps[0])
+	}
+	if errObj["code"].(float64) != codeMethodNotFound {
+		t.Errorf("code = %v, want %d", errObj["code"], codeMethodNotFound)
+	}
+}
+
+func TestMissingToolNameIsInvalidParams(t *testing.T) {
+	resps := run(t, `{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"arguments":{}}}`)
+	errObj, ok := resps[0]["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("want error response, got %v", resps[0])
+	}
+	if errObj["code"].(float64) != codeInvalidParams {
+		t.Errorf("code = %v, want %d", errObj["code"], codeInvalidParams)
+	}
+}
+
+func TestMalformedLineIsParseErrorWithNullID(t *testing.T) {
+	resps := run(t, `{not json`)
+	if len(resps) != 1 {
+		t.Fatalf("want 1 response, got %d", len(resps))
+	}
+	if resps[0]["id"] != nil {
+		t.Errorf("parse error id = %v, want null", resps[0]["id"])
+	}
+	errObj := resps[0]["error"].(map[string]any)
+	if errObj["code"].(float64) != codeParse {
+		t.Errorf("code = %v, want %d", errObj["code"], codeParse)
+	}
+}


### PR DESCRIPTION
Adds two adapters over the same `internal/aitools` catalog so an agent can both **query** the verifiable graph and **assert its own app-side context** within the trust boundary.

- **`internal/mcpserver`** — stdio JSON-RPC 2.0 MCP server (spec 2025-06-18) rendering the same `aitools.Catalog()`/`Dispatch` as the provider adapters (`initialize`/`tools/list`/`tools/call`, per-tool `readOnlyHint`, JSON-RPC only on stdout). `agentprov ai mcp`.
- **context-write tools** — `Tool.Writes` flag; `bind_scope` (register a ToolCallScope binding, forced `binding_source=ai_asserted`) and `record_tool_call` (anchor an app-asserted `tool_calls` row, **no execution**). App-asserted only — never fabricates system events or signatures.

Tested: catalog/handshake/gate + the write tools against a real store. `go vet`/`go test ./...`/`gofmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)