### PR TITLE
v0.7.1: Zero-touch k8s attribution + multi-harness app-context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v0.7.1 - 2026-07-09
+
+Zero-touch k8s attribution and multi-harness app-context. Capturing a pod is now
+one command (or auto), egress resolves to domains, node-side response capture is
+reliable, and the app-context layer — previously Claude Code only — reads the
+session transcripts of Kimi Code and Codex too, all validated end-to-end.
+
+### Added
+
+- **`agentprov sandbox capture` — one-shot k8s pod attribution.** Collapses the
+  manual node-side flow (resolve pid/cgroup, pull pod metadata, bind-cgroup, run
+  the sensor, ingest) into a single command; `--container` pins to a named
+  container in a multi-container pod. Points the sensor's libssl/libc uprobes at
+  the pod's own `/proc/<pid>/root`, so model intent and DNS are captured node-side.
+- **`agentprov sandbox watch` — auto-attribution (phase-2 preview).** A node-side
+  control loop that discovers pods and binds each to a run with no per-pod command
+  (`agentprov.io/run` annotation opts into a named run, else an auto-run per UID).
+  Honestly a kubectl poll, not yet a client-go informer; a single per-round sensor
+  means model-intent coverage is weaker than `capture` (use `capture` for that).
+- **Egress resolves to domains.** Pointing the getaddrinfo uprobe at a pod's own
+  libc captures its DNS lookups; the dashboard correlates each `dns_query` hostname
+  to the connect that follows, so egress shows `api.deepseek.com`, not just the IP.
+- **Multi-harness app-context (`hooks bridge --harness kimi|codex|claude`).** The
+  major coding CLIs aren't black boxes — they write rich session transcripts, and
+  some reuse Claude Code's hook vocabulary. A thin per-harness adapter normalizes
+  each transcript into the existing bridge: Kimi Code's `wire.jsonl` (single- and
+  multi-agent delegation, merged into one wall-clock timeline) and Codex's
+  `rollout-*.jsonl` (its `exec_command` shell tool normalized to Bash for
+  command-match). All three harnesses validated end-to-end against a live run.
+
+### Fixed
+
+- **Node-side `tls_read` reliability.** Close-framed HTTP responses had no in-band
+  terminator, so on a reused SSL* connection they stayed buffered and were lost on
+  a long-lived workload; a new request now flushes the pending response. Node-side
+  tls_read went 0 → 1:1 with tls_write. Partial TLS-uprobe attach is surfaced.
+
 ## v0.7.0 - 2026-07-08
 
 Portable Producer Profiles. Evidence collection extends from local/VM to

--- a/cmd/agentprov-sensor/main.go
+++ b/cmd/agentprov-sensor/main.go
@@ -17,6 +17,7 @@ func main() {
 	opts := sensor.Options{
 		SSLLib:   os.Getenv("AGENTPROV_SSL_LIB"),
 		GoTLSBin: os.Getenv("AGENTPROV_GO_TLS_BIN"),
+		LibcLib:  os.Getenv("AGENTPROV_LIBC_LIB"),
 	}
 	if err := sensor.RunWithOptions(os.Stdout, opts); err != nil {
 		fmt.Fprintln(os.Stderr, "agentprov-sensor:", err)

--- a/docs/design-k8s-auto-attribution.md
+++ b/docs/design-k8s-auto-attribution.md
@@ -1,0 +1,85 @@
+# Design: zero-touch K8s pod attribution (auto pod-scope binding)
+
+Status: proposal for sign-off. Turns the k8s-daemonset profile from a manual
+node-side script into `kubectl apply` + it-just-works.
+
+## Problem
+
+Today the sensor deploys as a DaemonSet (`deploy/k8s/agentprov-sensor-daemonset.yaml`)
+and streams events, but attributing a pod's telemetry to a run is manual: resolve
+`pid → cgroup`, read pod metadata from the K8s API, call `sandbox bind-cgroup`
+per pod, then ingest. That is the ~12-step flow in `scripts/demo_k8s_a2a.sh`.
+Nobody deploys that. The barrier is the gap between "sensor sees the cgroup" and
+"scope is bound to it."
+
+The pieces already exist and are reused, not rebuilt:
+- `cgroupResolver` (`internal/sensor/sensor_linux.go`) already parses
+  `kubepods/<uid>/…<container-id>` → container id from the cgroup dir name.
+- `producer.BindCgroupScope` / `correlation.RecordBinding` write the binding row
+  (`k8s_cgroup`, confidence 0.8). **No schema change.**
+- The daemon ingest API (`POST /v1/telemetry/*`) already accepts streamed events.
+- `bind-cgroup` already records pod metadata as a context event.
+
+The only missing thing is the **glue that watches pods and binds automatically**.
+
+## Two phases
+
+### Phase 1 — `agentprov sandbox capture` (one-shot, manual trigger) ← build first
+
+A single node-side command that collapses the manual flow for one running pod:
+
+```
+agentprov sandbox capture --pod <name> --namespace <ns> \
+  [--run <id>] [--seconds 45] [--kubectl "k3s kubectl"]
+```
+
+It does, in-process, exactly what the demo script does by hand:
+1. Resolve the pod's `pid` (scan `/proc/*/cgroup` for the pod's cgroup, or take
+   `--pid`), its cgroup id (`stat -c %i`), and pull pod metadata from the K8s API
+   (namespace/uid/node/container/image/service-account/labels/pod-ip) via kubectl.
+2. Run the sensor for `--seconds` (or attach to an already-running DaemonSet
+   sensor's spool), filtered to the pod's cgroup.
+3. `bind-cgroup` (all metadata auto-filled) + ingest the pod-scoped events into
+   the run.
+4. Print the one-line attribution result (run id, cgroup, confidence).
+
+Value: the 12-step script becomes one command. Pure Go + kubectl exec; no eBPF
+change; testable on the lab VM immediately. This is the near-term face of #1 and
+de-risks phase 2.
+
+### Phase 2 — informer/controller (auto, zero-touch) ← the product shape
+
+A control loop (runs in the DaemonSet pod, or as a small sidecar) that:
+1. Watches the K8s API for pods scheduled on this node (a client-go informer, or
+   — to avoid the client-go dep — polls `kubelet /pods` or `crictl`).
+2. For each new pod, resolves its cgroup (the informer gives the pod UID; the
+   cgroup path is `kubepods…/pod<uid>` — already the format `cgroupResolver`
+   knows), and calls the same `BindCgroupScope` + metadata enrichment as phase 1,
+   automatically, at pod start.
+3. The DaemonSet sensor already streams events tagged with `cgroup_id`; the
+   binding makes them attribute to the pod's run with no per-pod action.
+
+Result: `kubectl apply -f agentprov-sensor-daemonset.yaml` and every pod on the
+node is attributed automatically. A pod annotation (e.g.
+`agentprov.io/run: <id>`) lets a workload opt its telemetry into a named run;
+absent that, each pod gets an auto-run keyed by its UID.
+
+Open choice for phase 2: **client-go informer** (accurate, adds a large dep +
+RBAC) vs **kubelet/crictl poll** (no dep, works with the existing node mounts,
+slightly less immediate). Recommendation: start with the kubelet/crictl poll (no
+new dep, matches the "node sensor is self-contained" posture); add the informer
+only if sub-second pod-start attribution is needed.
+
+## Scope / non-goals
+
+- No core/graph/schema change (consistent with v0.7's whole premise).
+- Not a scheduler; not prevention; detect-mode only.
+- Model-intent (TLS) capture is orthogonal and unchanged here (#2/#3 track it).
+
+## Acceptance
+
+- `agentprov sandbox capture --pod X` on the lab VM: a pod never touched by
+  `record` gets attributed + `graph verify errors=0` — same as the manual demo,
+  one command.
+- Phase 2: deploy the DaemonSet, start a pod, and its telemetry shows up
+  attributed to a run with no manual step, within N seconds of pod start.

--- a/internal/cli/hooks_cmd.go
+++ b/internal/cli/hooks_cmd.go
@@ -24,7 +24,7 @@ func hooksCmd(dataDir *string) *cobra.Command {
 }
 
 func hooksBridgeCmd(dataDir *string) *cobra.Command {
-	var runID, file string
+	var runID, file, harness string
 	var correlate bool
 	cmd := &cobra.Command{
 		Use:   "bridge",
@@ -53,6 +53,10 @@ func hooksBridgeCmd(dataDir *string) *cobra.Command {
 				defer f.Close()
 				r = f
 			}
+			r, err = hooksbridge.AdaptHarness(harness, r)
+			if err != nil {
+				return err
+			}
 			sum, err := hooksbridge.Ingest(db, r, hooksbridge.Options{
 				RunID:   runID,
 				Objects: provenance.ObjectStore{DB: db, Paths: paths},
@@ -80,5 +84,6 @@ func hooksBridgeCmd(dataDir *string) *cobra.Command {
 	cmd.Flags().StringVar(&runID, "run", "", "run id to attach the orchestration graph to")
 	cmd.Flags().StringVar(&file, "file", "-", "hook JSONL file (default stdin)")
 	cmd.Flags().BoolVar(&correlate, "correlate", true, "attribute sensor syscall events to the acting agent by command-match")
+	cmd.Flags().StringVar(&harness, "harness", "claude", "harness whose session transcript this is: claude | kimi | codex")
 	return cmd
 }

--- a/internal/cli/hooks_cmd.go
+++ b/internal/cli/hooks_cmd.go
@@ -45,17 +45,32 @@ func hooksBridgeCmd(dataDir *string) *cobra.Command {
 			defer db.Close()
 
 			r := cmd.InOrStdin()
-			if file != "" && file != "-" {
-				f, err := os.Open(file)
+			kimiSession := ""
+			// A Kimi session directory carries a per-agent wire.jsonl each; walk
+			// them all so sub-agent delegation is captured, not just the main agent.
+			if harness == "kimi" && file != "" && file != "-" {
+				if info, statErr := os.Stat(file); statErr == nil && info.IsDir() {
+					kimiSession = file
+				}
+			}
+			if kimiSession != "" {
+				r, err = hooksbridge.AdaptKimiSession(kimiSession)
 				if err != nil {
 					return err
 				}
-				defer f.Close()
-				r = f
-			}
-			r, err = hooksbridge.AdaptHarness(harness, r)
-			if err != nil {
-				return err
+			} else {
+				if file != "" && file != "-" {
+					f, err := os.Open(file)
+					if err != nil {
+						return err
+					}
+					defer f.Close()
+					r = f
+				}
+				r, err = hooksbridge.AdaptHarness(harness, r)
+				if err != nil {
+					return err
+				}
 			}
 			sum, err := hooksbridge.Ingest(db, r, hooksbridge.Options{
 				RunID:   runID,

--- a/internal/cli/sandbox_capture_cmd.go
+++ b/internal/cli/sandbox_capture_cmd.go
@@ -26,7 +26,7 @@ import (
 // from the K8s API, run the node sensor for a window, bind the pod's cgroup to a
 // run, and ingest its telemetry. No manual bind-cgroup / kubectl glue.
 func sandboxCaptureCmd(dataDir *string) *cobra.Command {
-	var runID, pod, namespace, kubectl, sensorBin, sslLib string
+	var runID, pod, namespace, kubectl, sensorBin, sslLib, container string
 	var seconds, pid int
 	cmd := &cobra.Command{
 		Use:   "capture",
@@ -49,7 +49,14 @@ func sandboxCaptureCmd(dataDir *string) *cobra.Command {
 				return fmt.Errorf("resolve pod metadata: %w", err)
 			}
 			if pid == 0 {
-				pid, err = findPodPID(meta.UID)
+				cid := ""
+				if container != "" {
+					// Pin to a named container in a multi-container pod.
+					cid, _ = runKubectl(kc, "get", "pod", pod, "-n", namespace,
+						"-o", "jsonpath={.status.containerStatuses[?(@.name==\""+container+"\")].containerID}")
+					meta.Container = container
+				}
+				pid, err = findPodPID(meta.UID, cid)
 				if err != nil {
 					return fmt.Errorf("resolve pod pid (pass --pid): %w", err)
 				}
@@ -98,6 +105,7 @@ func sandboxCaptureCmd(dataDir *string) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&runID, "run", "", "run id to attribute the pod to (default: generated)")
 	cmd.Flags().StringVar(&pod, "pod", "", "pod name (required)")
+	cmd.Flags().StringVar(&container, "container", "", "container name to pin to (multi-container pods); default: the pod's first non-pause process")
 	cmd.Flags().StringVar(&namespace, "namespace", "", "pod namespace (required)")
 	cmd.Flags().StringVar(&kubectl, "kubectl", "kubectl", "kubectl command (e.g. \"k3s kubectl\")")
 	cmd.Flags().StringVar(&sensorBin, "sensor", "", "path to agentprov-sensor (required)")
@@ -144,16 +152,22 @@ func runKubectl(kc []string, args ...string) (string, error) {
 // this pod UID (kubepods…/pod<uid>, dashes underscore-normalized by the kubelet)
 // but is NOT the `pause` sandbox container, whose cgroup leaf differs from the
 // app container's and carries none of the workload's syscalls.
-func findPodPID(uid string) (int, error) {
+func findPodPID(uid, containerID string) (int, error) {
 	if uid == "" {
 		return 0, fmt.Errorf("empty pod uid")
 	}
 	needles := []string{"pod" + strings.ReplaceAll(uid, "-", "_"), "pod" + uid}
+	// A multi-container pod has one cgroup leaf per container; when a specific
+	// container is requested, pin to the process whose cgroup names its id, not
+	// merely the first non-pause process in the pod.
+	containerID = strings.TrimSpace(containerID)
+	if i := strings.LastIndex(containerID, "/"); i >= 0 {
+		containerID = containerID[i+1:] // strip a containerd://<id> scheme
+	}
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return 0, err
 	}
-	fallback := 0 // a matching pid even if we can't rule out pause
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
@@ -176,14 +190,17 @@ func findPodPID(uid string) (int, error) {
 		if !matched {
 			continue
 		}
+		if containerID != "" && !strings.Contains(string(cg), containerID) {
+			continue // not the requested container's cgroup leaf
+		}
 		comm, _ := os.ReadFile(filepath.Join("/proc", e.Name(), "comm"))
 		if strings.TrimSpace(string(comm)) == "pause" {
 			continue // the sandbox container — not where the workload runs
 		}
 		return p, nil
 	}
-	if fallback != 0 {
-		return fallback, nil
+	if containerID != "" {
+		return 0, fmt.Errorf("no process found in container %s of pod uid %s on this node", containerID, uid)
 	}
 	return 0, fmt.Errorf("no app process found in cgroup for pod uid %s (is the pod running on this node?)", uid)
 }

--- a/internal/cli/sandbox_capture_cmd.go
+++ b/internal/cli/sandbox_capture_cmd.go
@@ -1,0 +1,294 @@
+package cli
+
+import (
+	"bufio"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/byteyellow/agentprovenance/internal/ids"
+	"github.com/byteyellow/agentprovenance/internal/producer"
+	"github.com/byteyellow/agentprovenance/internal/store"
+	"github.com/byteyellow/agentprovenance/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+// sandboxCaptureCmd is phase 1 of zero-touch k8s attribution (see
+// docs/design-k8s-auto-attribution.md): one node-side command that collapses the
+// manual demo flow for one running pod — resolve pid/cgroup + pull pod metadata
+// from the K8s API, run the node sensor for a window, bind the pod's cgroup to a
+// run, and ingest its telemetry. No manual bind-cgroup / kubectl glue.
+func sandboxCaptureCmd(dataDir *string) *cobra.Command {
+	var runID, pod, namespace, kubectl, sensorBin, sslLib string
+	var seconds, pid int
+	cmd := &cobra.Command{
+		Use:   "capture",
+		Short: "one-shot: attribute a running k8s pod's node-observed telemetry to a run",
+		RunE: func(c *cobra.Command, _ []string) error {
+			if pod == "" || namespace == "" {
+				return fmt.Errorf("--pod and --namespace are required")
+			}
+			if sensorBin == "" {
+				return fmt.Errorf("--sensor (path to agentprov-sensor) is required")
+			}
+			if runID == "" {
+				runID = ids.New("run")
+			}
+			stderr := c.ErrOrStderr()
+			kc := strings.Fields(kubectl)
+
+			meta, err := resolvePodMetadata(kc, pod, namespace)
+			if err != nil {
+				return fmt.Errorf("resolve pod metadata: %w", err)
+			}
+			if pid == 0 {
+				pid, err = findPodPID(meta.UID)
+				if err != nil {
+					return fmt.Errorf("resolve pod pid (pass --pid): %w", err)
+				}
+			}
+			cgroupID, err := cgroupInodeForPID(pid)
+			if err != nil {
+				return fmt.Errorf("resolve pod cgroup: %w", err)
+			}
+			meta.CgroupID = cgroupID
+			fmt.Fprintf(c.OutOrStdout(), "pod=%s/%s uid=%s pid=%d cgroup=%s node=%s\n", namespace, pod, meta.UID, pid, cgroupID, meta.Node)
+
+			paths, err := store.Init(*dataDir)
+			if err != nil {
+				return err
+			}
+			db, err := store.Open(paths)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			started := time.Now().UTC().Format(time.RFC3339Nano)
+			raw := filepath.Join(paths.Logs, "capture-"+runID+"-sensor.jsonl")
+			if err := runSensorWindow(sensorBin, raw, sslLib, pid, seconds, stderr); err != nil {
+				return fmt.Errorf("run sensor: %w", err)
+			}
+			scoped := raw + ".pod"
+			kept, err := filterByCgroup(raw, scoped, cgroupID)
+			if err != nil {
+				return fmt.Errorf("filter pod events: %w", err)
+			}
+
+			if _, err := producer.BindCgroupScope(db, cgroupID, producer.RunScope{RunID: runID, SessionID: meta.UID, StartedAt: started}); err != nil {
+				return fmt.Errorf("bind cgroup: %w", err)
+			}
+			if err := writePodMetadataEvent(db, runID, meta); err != nil {
+				fmt.Fprintf(stderr, "capture: pod metadata event: %v\n", err)
+			}
+			res, err := telemetry.IngestJSONL(db, telemetry.JSONLIngestOptions{Format: "native", Path: scoped, RunID: runID})
+			if err != nil {
+				return fmt.Errorf("ingest: %w", err)
+			}
+			fmt.Fprintf(c.OutOrStdout(), "captured=%d ingested=%d run=%s scope=k8s_cgroup confidence=0.8\n", kept, res.Ingested, runID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&runID, "run", "", "run id to attribute the pod to (default: generated)")
+	cmd.Flags().StringVar(&pod, "pod", "", "pod name (required)")
+	cmd.Flags().StringVar(&namespace, "namespace", "", "pod namespace (required)")
+	cmd.Flags().StringVar(&kubectl, "kubectl", "kubectl", "kubectl command (e.g. \"k3s kubectl\")")
+	cmd.Flags().StringVar(&sensorBin, "sensor", "", "path to agentprov-sensor (required)")
+	cmd.Flags().StringVar(&sslLib, "ssl-lib", "", "libssl path for model-intent uprobe; empty = pod's own libssl via /proc/<pid>/root")
+	cmd.Flags().IntVar(&seconds, "seconds", 45, "sensor capture window")
+	cmd.Flags().IntVar(&pid, "pid", 0, "pod's main pid (default: auto-resolved from the pod cgroup)")
+	return cmd
+}
+
+type podMeta struct {
+	Name, Namespace, UID, Node, Container, Image, ServiceAccount, Labels, PodIP, CgroupID string
+}
+
+// resolvePodMetadata pulls the pod's identity from the K8s API in one kubectl call.
+func resolvePodMetadata(kc []string, pod, namespace string) (podMeta, error) {
+	m := podMeta{Name: pod, Namespace: namespace}
+	jsonpath := "{.metadata.uid}|{.spec.nodeName}|{.spec.containers[0].name}|" +
+		"{.spec.containers[0].image}|{.spec.serviceAccountName}|{.status.podIP}"
+	out, err := runKubectl(kc, "get", "pod", pod, "-n", namespace, "-o", "jsonpath="+jsonpath)
+	if err != nil {
+		return m, err
+	}
+	f := strings.Split(strings.TrimSpace(out), "|")
+	for len(f) < 6 {
+		f = append(f, "")
+	}
+	m.UID, m.Node, m.Container, m.Image, m.ServiceAccount, m.PodIP = f[0], f[1], f[2], f[3], f[4], f[5]
+	if labels, err := runKubectl(kc, "get", "pod", pod, "-n", namespace, "-o", "jsonpath={.metadata.labels}"); err == nil {
+		m.Labels = strings.TrimSpace(labels)
+	}
+	return m, nil
+}
+
+func runKubectl(kc []string, args ...string) (string, error) {
+	if len(kc) == 0 {
+		kc = []string{"kubectl"}
+	}
+	cmd := exec.Command(kc[0], append(kc[1:], args...)...)
+	out, err := cmd.Output()
+	return string(out), err
+}
+
+// findPodPID scans /proc for the pod's APP process — one whose cgroup path names
+// this pod UID (kubepods…/pod<uid>, dashes underscore-normalized by the kubelet)
+// but is NOT the `pause` sandbox container, whose cgroup leaf differs from the
+// app container's and carries none of the workload's syscalls.
+func findPodPID(uid string) (int, error) {
+	if uid == "" {
+		return 0, fmt.Errorf("empty pod uid")
+	}
+	needles := []string{"pod" + strings.ReplaceAll(uid, "-", "_"), "pod" + uid}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0, err
+	}
+	fallback := 0 // a matching pid even if we can't rule out pause
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		var p int
+		if _, err := fmt.Sscanf(e.Name(), "%d", &p); err != nil || p == 0 {
+			continue
+		}
+		cg, err := os.ReadFile(filepath.Join("/proc", e.Name(), "cgroup"))
+		if err != nil {
+			continue
+		}
+		matched := false
+		for _, n := range needles {
+			if strings.Contains(string(cg), n) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		comm, _ := os.ReadFile(filepath.Join("/proc", e.Name(), "comm"))
+		if strings.TrimSpace(string(comm)) == "pause" {
+			continue // the sandbox container — not where the workload runs
+		}
+		return p, nil
+	}
+	if fallback != 0 {
+		return fallback, nil
+	}
+	return 0, fmt.Errorf("no app process found in cgroup for pod uid %s (is the pod running on this node?)", uid)
+}
+
+// cgroupInodeForPID resolves the kernel cgroup id (the inode the sensor stamps)
+// for a pid from its cgroup2 path.
+func cgroupInodeForPID(pid int) (string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "", err
+	}
+	rel := ""
+	for _, line := range strings.Split(string(data), "\n") {
+		if i := strings.Index(line, "::"); i >= 0 {
+			rel = line[i+2:]
+			break
+		}
+	}
+	if rel == "" {
+		return "", fmt.Errorf("no cgroup2 path in /proc/%d/cgroup", pid)
+	}
+	info, err := os.Stat(filepath.Join("/sys/fs/cgroup", rel))
+	if err != nil {
+		return "", err
+	}
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		return fmt.Sprintf("%d", st.Ino), nil
+	}
+	return "", fmt.Errorf("cannot read cgroup inode")
+}
+
+// runSensorWindow runs the node sensor for a fixed window, writing raw JSONL. It
+// points the model-intent uprobe at the pod's own libssl (reached via
+// /proc/<pid>/root) unless an explicit --ssl-lib is given.
+func runSensorWindow(sensorBin, out, sslLib string, pid, seconds int, stderr io.Writer) error {
+	f, err := os.Create(out)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	proc := exec.Command(sensorBin)
+	proc.Stdout = f
+	if ef, e := os.Create(out + ".err"); e == nil {
+		proc.Stderr = ef
+		defer ef.Close()
+	}
+	proc.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	proc.Env = os.Environ()
+	if sslLib == "" && pid > 0 {
+		for _, cand := range []string{
+			fmt.Sprintf("/proc/%d/root/usr/lib/aarch64-linux-gnu/libssl.so.3", pid),
+			fmt.Sprintf("/proc/%d/root/usr/lib/x86_64-linux-gnu/libssl.so.3", pid),
+		} {
+			if _, e := os.Stat(cand); e == nil {
+				sslLib = cand
+				break
+			}
+		}
+	}
+	if sslLib != "" {
+		proc.Env = append(proc.Env, "AGENTPROV_SSL_LIB="+sslLib)
+	}
+	if err := proc.Start(); err != nil {
+		return err
+	}
+	time.Sleep(time.Duration(seconds) * time.Second)
+	if proc.Process != nil {
+		_ = syscall.Kill(-proc.Process.Pid, syscall.SIGINT)
+	}
+	_ = proc.Wait()
+	return nil
+}
+
+func writePodMetadataEvent(db *sql.DB, runID string, m podMeta) error {
+	payload, _ := json.Marshal(map[string]any{
+		"pod_name": m.Name, "namespace": m.Namespace, "pod_uid": m.UID, "cgroup_id": m.CgroupID,
+		"cluster": "", "node": m.Node, "container": m.Container, "image": m.Image,
+		"service_account": m.ServiceAccount, "labels": m.Labels, "pod_ip": m.PodIP,
+	})
+	_, err := db.Exec(`INSERT INTO events (id, run_id, session_id, tool_call_id, process_id, source, event_type, payload, created_at)
+		VALUES (?, ?, ?, '', '', 'k8s', 'pod_metadata', ?, ?)`,
+		ids.New("evt"), runID, m.UID, string(payload), time.Now().UTC().Format(time.RFC3339Nano))
+	return err
+}
+
+func filterByCgroup(src, dst, cgroupID string) (int, error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return 0, err
+	}
+	defer out.Close()
+	needle := `"cgroup_id":"` + cgroupID + `"`
+	n := 0
+	sc := bufio.NewScanner(in)
+	sc.Buffer(make([]byte, 0, 1024*1024), 8*1024*1024)
+	for sc.Scan() {
+		if strings.Contains(sc.Text(), needle) {
+			fmt.Fprintln(out, sc.Text())
+			n++
+		}
+	}
+	return n, sc.Err()
+}

--- a/internal/cli/sandbox_capture_cmd.go
+++ b/internal/cli/sandbox_capture_cmd.go
@@ -246,6 +246,20 @@ func runSensorWindow(sensorBin, out, sslLib string, pid, seconds int, stderr io.
 	if sslLib != "" {
 		proc.Env = append(proc.Env, "AGENTPROV_SSL_LIB="+sslLib)
 	}
+	if pid > 0 {
+		// Point the getaddrinfo DNS uprobe at the pod's own libc so egress gets
+		// resolved by NAME (not just IP) node-side, mirroring the libssl trick.
+		for _, cand := range []string{
+			fmt.Sprintf("/proc/%d/root/usr/lib/aarch64-linux-gnu/libc.so.6", pid),
+			fmt.Sprintf("/proc/%d/root/usr/lib/x86_64-linux-gnu/libc.so.6", pid),
+			fmt.Sprintf("/proc/%d/root/lib/aarch64-linux-gnu/libc.so.6", pid),
+		} {
+			if _, e := os.Stat(cand); e == nil {
+				proc.Env = append(proc.Env, "AGENTPROV_LIBC_LIB="+cand)
+				break
+			}
+		}
+	}
 	if err := proc.Start(); err != nil {
 		return err
 	}

--- a/internal/cli/sandbox_cmd.go
+++ b/internal/cli/sandbox_cmd.go
@@ -243,6 +243,7 @@ func sandboxCmd(dataDir *string) *cobra.Command {
 	bindCgroup.Flags().StringVar(&bcServiceAccount, "service-account", "", "service account for metadata enrichment")
 	bindCgroup.Flags().StringVar(&bcPodIP, "pod-ip", "", "pod IP for cross-pod influence edges (substrate lens)")
 	cmd.AddCommand(bindCgroup)
+	cmd.AddCommand(sandboxCaptureCmd(dataDir))
 
 	run.Flags().SetInterspersed(false)
 	run.Flags().StringVar(&out, "out", "", "directory to copy the exported bundle into (mounted volume for teardown durability)")

--- a/internal/cli/sandbox_cmd.go
+++ b/internal/cli/sandbox_cmd.go
@@ -244,6 +244,7 @@ func sandboxCmd(dataDir *string) *cobra.Command {
 	bindCgroup.Flags().StringVar(&bcPodIP, "pod-ip", "", "pod IP for cross-pod influence edges (substrate lens)")
 	cmd.AddCommand(bindCgroup)
 	cmd.AddCommand(sandboxCaptureCmd(dataDir))
+	cmd.AddCommand(sandboxWatchCmd(dataDir))
 
 	run.Flags().SetInterspersed(false)
 	run.Flags().StringVar(&out, "out", "", "directory to copy the exported bundle into (mounted volume for teardown durability)")

--- a/internal/cli/sandbox_watch_cmd.go
+++ b/internal/cli/sandbox_watch_cmd.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/byteyellow/agentprovenance/internal/producer"
+	"github.com/byteyellow/agentprovenance/internal/store"
+	"github.com/byteyellow/agentprovenance/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+// sandboxWatchCmd is phase 2 of zero-touch k8s attribution (see
+// docs/design-k8s-auto-attribution.md): a node-side control loop that discovers
+// pods scheduled on this node and auto-binds each to a run, so their telemetry
+// attributes with no per-pod command. A pod opts into a named run via the
+// `agentprov.io/run` annotation; otherwise it gets an auto-run keyed by its UID.
+// Reuses the phase-1 capture resolution (kubectl poll, not a client-go informer,
+// keeping the node sensor self-contained).
+func sandboxWatchCmd(dataDir *string) *cobra.Command {
+	var namespace, kubectl, sensorBin string
+	var window, rounds int
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "auto-attribute every pod on this node to a run (zero-touch k8s-daemonset)",
+		RunE: func(c *cobra.Command, _ []string) error {
+			if sensorBin == "" {
+				return fmt.Errorf("--sensor (path to agentprov-sensor) is required")
+			}
+			paths, err := store.Init(*dataDir)
+			if err != nil {
+				return err
+			}
+			db, err := store.Open(paths)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			kc := strings.Fields(kubectl)
+			out, stderr := c.OutOrStdout(), c.ErrOrStderr()
+
+			boundCgroup := map[string]string{} // cgroup_id -> run (already bound)
+			for round := 0; rounds == 0 || round < rounds; round++ {
+				pods, err := listPods(kc, namespace)
+				if err != nil {
+					fmt.Fprintf(stderr, "watch: list pods: %v\n", err)
+					time.Sleep(time.Duration(window) * time.Second)
+					continue
+				}
+				// Resolve + bind any pod on THIS node not yet bound. findPodPID
+				// fails for pods on other nodes, which we simply skip.
+				roundPods := map[string]podMeta{} // cgroup_id -> meta (bound this session)
+				for _, p := range pods {
+					meta, err := resolvePodMetadata(kc, p.name, p.namespace)
+					if err != nil {
+						continue
+					}
+					pid, err := findPodPID(meta.UID)
+					if err != nil {
+						continue // not on this node (or not running)
+					}
+					cg, err := cgroupInodeForPID(pid)
+					if err != nil {
+						continue
+					}
+					meta.CgroupID = cg
+					run := boundCgroup[cg]
+					if run == "" {
+						run = podRunID(kc, p.name, p.namespace, meta.UID)
+						started := time.Now().UTC().Format(time.RFC3339Nano)
+						if _, err := producer.BindCgroupScope(db, cg, producer.RunScope{RunID: run, SessionID: meta.UID, StartedAt: started}); err != nil {
+							fmt.Fprintf(stderr, "watch: bind %s/%s: %v\n", p.namespace, p.name, err)
+							continue
+						}
+						_ = writePodMetadataEvent(db, run, meta)
+						boundCgroup[cg] = run
+						fmt.Fprintf(out, "bound %s/%s cgroup=%s -> run=%s\n", p.namespace, p.name, cg, run)
+					}
+					roundPods[cg] = meta
+				}
+				if len(roundPods) == 0 {
+					time.Sleep(time.Duration(window) * time.Second)
+					continue
+				}
+				// One sensor window covers every bound cgroup; ingest per pod.
+				raw := filepath.Join(paths.Logs, fmt.Sprintf("watch-r%d-sensor.jsonl", round))
+				if err := runSensorWindow(sensorBin, raw, "", 0, window, stderr); err != nil {
+					fmt.Fprintf(stderr, "watch: sensor: %v\n", err)
+					continue
+				}
+				for cg, meta := range roundPods {
+					scoped := raw + "." + cg
+					if _, err := filterByCgroup(raw, scoped, cg); err != nil {
+						continue
+					}
+					res, err := telemetry.IngestJSONL(db, telemetry.JSONLIngestOptions{Format: "native", Path: scoped, RunID: boundCgroup[cg]})
+					if err != nil {
+						fmt.Fprintf(stderr, "watch: ingest %s: %v\n", meta.Name, err)
+						continue
+					}
+					if res.Ingested > 0 {
+						fmt.Fprintf(out, "attributed %s/%s: %d events -> run=%s\n", meta.Namespace, meta.Name, res.Ingested, boundCgroup[cg])
+					}
+				}
+				_ = os.Remove(raw)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&namespace, "namespace", "", "limit to one namespace (default: all)")
+	cmd.Flags().StringVar(&kubectl, "kubectl", "kubectl", "kubectl command (e.g. \"k3s kubectl\")")
+	cmd.Flags().StringVar(&sensorBin, "sensor", "", "path to agentprov-sensor (required)")
+	cmd.Flags().IntVar(&window, "window", 30, "sensor capture window per round (seconds)")
+	cmd.Flags().IntVar(&rounds, "rounds", 0, "number of rounds; 0 = run until stopped")
+	return cmd
+}
+
+type podRef struct{ namespace, name string }
+
+// listPods returns running pods (all namespaces or one). Pods not on this node
+// are filtered out later by findPodPID failing to resolve them.
+func listPods(kc []string, namespace string) ([]podRef, error) {
+	args := []string{"get", "pods", "--field-selector=status.phase=Running",
+		"-o", "jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{\"\\n\"}{end}"}
+	if namespace != "" {
+		args = append([]string{"get", "pods", "-n", namespace}, args[2:]...)
+	} else {
+		args = append(args, "--all-namespaces")
+	}
+	out, err := runKubectl(kc, args...)
+	if err != nil {
+		return nil, err
+	}
+	var pods []podRef
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if i := strings.IndexByte(line, '/'); i > 0 {
+			pods = append(pods, podRef{line[:i], line[i+1:]})
+		}
+	}
+	return pods, nil
+}
+
+// podRunID reads the pod's agentprov.io/run annotation (explicit opt-in to a
+// named run) or falls back to an auto-run keyed by the pod UID.
+func podRunID(kc []string, pod, namespace, uid string) string {
+	out, err := runKubectl(kc, "get", "pod", pod, "-n", namespace,
+		"-o", "jsonpath={.metadata.annotations.agentprov\\.io/run}")
+	if run := strings.TrimSpace(out); err == nil && run != "" {
+		return run
+	}
+	return "auto-" + uid
+}

--- a/internal/cli/sandbox_watch_cmd.go
+++ b/internal/cli/sandbox_watch_cmd.go
@@ -25,7 +25,12 @@ func sandboxWatchCmd(dataDir *string) *cobra.Command {
 	var window, rounds int
 	cmd := &cobra.Command{
 		Use:   "watch",
-		Short: "auto-attribute every pod on this node to a run (zero-touch k8s-daemonset)",
+		Short: "auto-attribute every pod on this node to a run (k8s-daemonset, phase-2 preview)",
+		Long: "Phase-2 PREVIEW of zero-touch attribution: a kubectl-polling control loop, " +
+			"NOT yet a client-go informer/operator. One sensor window per round covers all " +
+			"bound cgroups, so — unlike `sandbox capture` — it does NOT set a per-pod " +
+			"AGENTPROV_SSL_LIB/AGENTPROV_LIBC_LIB, so model-intent (TLS) and DNS-domain " +
+			"coverage are weaker here; use `sandbox capture` for full per-pod model intent.",
 		RunE: func(c *cobra.Command, _ []string) error {
 			if sensorBin == "" {
 				return fmt.Errorf("--sensor (path to agentprov-sensor) is required")
@@ -58,7 +63,7 @@ func sandboxWatchCmd(dataDir *string) *cobra.Command {
 					if err != nil {
 						continue
 					}
-					pid, err := findPodPID(meta.UID)
+					pid, err := findPodPID(meta.UID, "")
 					if err != nil {
 						continue // not on this node (or not running)
 					}
@@ -85,7 +90,10 @@ func sandboxWatchCmd(dataDir *string) *cobra.Command {
 					time.Sleep(time.Duration(window) * time.Second)
 					continue
 				}
-				// One sensor window covers every bound cgroup; ingest per pod.
+				// One sensor window covers every bound cgroup. NOTE: because a single
+				// sensor serves all pods this round, it can't target one pod's libssl/
+				// libc (pid=0, sslLib=""), so model-intent/DNS coverage is weaker than
+				// `sandbox capture` — system telemetry + cgroup scope are the focus here.
 				raw := filepath.Join(paths.Logs, fmt.Sprintf("watch-r%d-sensor.jsonl", round))
 				if err := runSensorWindow(sensorBin, raw, "", 0, window, stderr); err != nil {
 					fmt.Fprintf(stderr, "watch: sensor: %v\n", err)

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -99,6 +99,11 @@ func (s Server) egress(w http.ResponseWriter, r *http.Request) {
 	}
 	defer rows.Close()
 	out := []map[string]any{}
+	// A getaddrinfo(hostname) immediately precedes the connect(resolved-IP) in the
+	// same process, so the most recent dns_query hostname per comm resolves the IP
+	// egress that follows it — giving egress a NAME, not just an IP, node-side.
+	lastHost := map[string]string{}
+	lastHostAny := ""
 	for rows.Next() {
 		var et, payload, created string
 		if err := rows.Scan(&et, &payload, &created); err != nil {
@@ -106,13 +111,26 @@ func (s Server) egress(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		raw := rawBody(payload)
+		comm := firstStr(raw, "comm")
+		if et == "dns_query" {
+			if h := firstStr(raw, "host"); h != "" {
+				lastHost[comm] = h
+				lastHostAny = h
+			}
+			continue // the resolution, not an egress row
+		}
+		domain := lastHost[comm]
+		if domain == "" {
+			domain = lastHostAny
+		}
 		out = append(out, map[string]any{
-			"type": et,
-			"dst":  firstStr(raw, "host", "dst_ip", "dst"),
-			"port": firstStr(raw, "port", "dst_port"),
-			"comm": firstStr(raw, "comm"),
-			"risk": et == "metadata_ip" || et == "private_cidr",
-			"time": created,
+			"type":   et,
+			"dst":    firstStr(raw, "host", "dst_ip", "dst"),
+			"domain": domain,
+			"port":   firstStr(raw, "port", "dst_port"),
+			"comm":   comm,
+			"risk":   et == "metadata_ip" || et == "private_cidr",
+			"time":   created,
 		})
 	}
 	writeJSON(w, out)

--- a/internal/dashboard/index.html
+++ b/internal/dashboard/index.html
@@ -1060,7 +1060,8 @@ function renderEgress(rows){
   tb.innerHTML=rows.map(e=>{
     const t=(e.time||'').replace('T',' ').replace(/\.\d+Z?$/,'');
     const cls=e.risk?'eg-risk':'eg-ok';
-    return `<tr><td>${esc(t)}</td><td class="${cls}">${esc(e.type)}</td><td class="${cls}">${esc(e.dst)}</td><td>${esc(e.port)}</td><td>${esc(e.comm)}</td></tr>`;
+    const dst=e.domain?`${esc(e.domain)} <span style="color:var(--mut);font-size:11px">${esc(e.dst)}</span>`:esc(e.dst);
+    return `<tr><td>${esc(t)}</td><td class="${cls}">${esc(e.type)}</td><td class="${cls}">${dst}</td><td>${esc(e.port)}</td><td>${esc(e.comm)}</td></tr>`;
   }).join('');
 }
 

--- a/internal/hooksbridge/adapters.go
+++ b/internal/hooksbridge/adapters.go
@@ -211,6 +211,12 @@ func adaptCodexRollout(r io.Reader) (io.Reader, error) {
 				name = "Bash"
 			}
 			ti := codexArgs(payload)
+			// Codex's shell tool (exec_command / local_shell) is where syscalls
+			// come from; normalize it to Bash with a `command` so command-match to
+			// the kernel works, exactly like Claude Code / Kimi.
+			if cmd := firstStr(ti, "command", "cmd"); cmd != "" && isCodexShellTool(name) {
+				name, ti = "Bash", map[string]any{"command": cmd}
+			}
 			out = append(out, normalizedEvent{Event: "PreToolUse", ToolName: name, ToolInput: ti, ToolUseID: firstStr(payload, "call_id", "id"), TS: ts})
 		case "function_call_output", "local_shell_call_output", "custom_tool_call_output":
 			out = append(out, normalizedEvent{Event: "PostToolUse", ToolUseID: firstStr(payload, "call_id", "id"), TS: ts})
@@ -220,6 +226,16 @@ func adaptCodexRollout(r io.Reader) (io.Reader, error) {
 		return nil, err
 	}
 	return encodeEvents(out)
+}
+
+// isCodexShellTool reports whether a codex tool name runs a shell command (so it
+// should be normalized to Bash for command-match).
+func isCodexShellTool(name string) bool {
+	switch name {
+	case "exec_command", "local_shell", "shell", "bash", "run", "container.exec":
+		return true
+	}
+	return name == "" // an unnamed local_shell_call
 }
 
 // codexArgs turns a codex tool item into a tool_input map, decoding the JSON

--- a/internal/hooksbridge/adapters.go
+++ b/internal/hooksbridge/adapters.go
@@ -109,12 +109,28 @@ func AdaptKimiSession(sessionDir string) (io.Reader, error) {
 		}
 	}
 	for _, s := range subs {
-		out = append(out, normalizedEvent{Event: "SubagentStart", AgentID: s, AgentType: kimiAgentType(filepath.Join(agentsDir, s, "wire.jsonl"))})
-		if err := appendAgent(s); err != nil {
+		f, err := os.Open(filepath.Join(agentsDir, s, "wire.jsonl"))
+		if err != nil {
 			return nil, err
 		}
-		out = append(out, normalizedEvent{Event: "SubagentStop", AgentID: s})
+		evs, err := kimiWireEvents(f, s)
+		f.Close()
+		if err != nil {
+			return nil, err
+		}
+		// Bracket the sub-agent's events with a Start/Stop stamped from its own
+		// timeline so the merged, time-sorted stream keeps them in causal order.
+		start, stop := "", ""
+		if len(evs) > 0 {
+			start, stop = evs[0].TS, evs[len(evs)-1].TS
+		}
+		out = append(out, normalizedEvent{Event: "SubagentStart", AgentID: s, AgentType: kimiAgentType(filepath.Join(agentsDir, s, "wire.jsonl")), TS: start})
+		out = append(out, evs...)
+		out = append(out, normalizedEvent{Event: "SubagentStop", AgentID: s, TS: stop})
 	}
+	// Merge every agent's events into one wall-clock timeline (stable, so events
+	// sharing a timestamp keep their per-agent emission order).
+	sort.SliceStable(out, func(i, j int) bool { return out[i].TS < out[j].TS })
 	return encodeEvents(out)
 }
 

--- a/internal/hooksbridge/adapters.go
+++ b/internal/hooksbridge/adapters.go
@@ -6,6 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"sort"
 	"time"
 )
 
@@ -33,6 +36,7 @@ type normalizedEvent struct {
 	ToolInput map[string]any `json:"tool_input,omitempty"`
 	ToolUseID string         `json:"tool_use_id,omitempty"`
 	AgentID   string         `json:"agent_id,omitempty"`
+	AgentType string         `json:"agent_type,omitempty"`
 	TS        string         `json:"timestamp,omitempty"`
 	LastMsg   string         `json:"last_assistant_message,omitempty"`
 }
@@ -54,8 +58,73 @@ func encodeEvents(evs []normalizedEvent) (io.Reader, error) {
 // kernel syscalls works unchanged. tool.call -> PreToolUse, tool.result ->
 // PostToolUse.
 func adaptKimiWire(r io.Reader) (io.Reader, error) {
+	evs, err := kimiWireEvents(r, "")
+	if err != nil {
+		return nil, err
+	}
+	return encodeEvents(evs)
+}
+
+// AdaptKimiSession walks a Kimi session directory (…/session_<id>/) and its
+// per-agent wire.jsonl files into one normalized hook stream. The main agent's
+// `Agent` tool call is the delegation dispatch (Kimi reuses Claude Code's tool
+// name), and each agents/<sub>/ becomes a SubagentStart + its own tool calls —
+// so the existing bridge draws the same delegation graph as Claude Code.
+func AdaptKimiSession(sessionDir string) (io.Reader, error) {
+	agentsDir := filepath.Join(sessionDir, "agents")
+	entries, err := os.ReadDir(agentsDir)
+	if err != nil {
+		return nil, err
+	}
+	var subs []string
+	hasMain := false
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if e.Name() == "main" {
+			hasMain = true
+		} else {
+			subs = append(subs, e.Name())
+		}
+	}
+	sort.Strings(subs)
 	var out []normalizedEvent
-	callTool := map[string]string{} // toolCallId -> tool name (to label the result)
+	appendAgent := func(id string) error {
+		f, err := os.Open(filepath.Join(agentsDir, id, "wire.jsonl"))
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		evs, err := kimiWireEvents(f, id)
+		if err != nil {
+			return err
+		}
+		out = append(out, evs...)
+		return nil
+	}
+	if hasMain {
+		if err := appendAgent("main"); err != nil {
+			return nil, err
+		}
+	}
+	for _, s := range subs {
+		out = append(out, normalizedEvent{Event: "SubagentStart", AgentID: s, AgentType: kimiAgentType(filepath.Join(agentsDir, s, "wire.jsonl"))})
+		if err := appendAgent(s); err != nil {
+			return nil, err
+		}
+		out = append(out, normalizedEvent{Event: "SubagentStop", AgentID: s})
+	}
+	return encodeEvents(out)
+}
+
+// kimiWireEvents parses one wire.jsonl into normalized events tagged with
+// agentID (empty = main). A tool.call named "Agent" is emitted as a delegation
+// dispatch (PreToolUse/Agent) with a resolvable teammate name; other tool.calls
+// map to PreToolUse and their results to PostToolUse.
+func kimiWireEvents(r io.Reader, agentID string) ([]normalizedEvent, error) {
+	var out []normalizedEvent
+	callTool := map[string]string{}
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 1024*1024), 8*1024*1024)
 	for sc.Scan() {
@@ -76,16 +145,44 @@ func adaptKimiWire(r io.Reader) (io.Reader, error) {
 			name := str(ev["name"])
 			callTool[id] = name
 			args, _ := ev["args"].(map[string]any)
-			out = append(out, normalizedEvent{Event: "PreToolUse", ToolName: name, ToolInput: args, ToolUseID: id, TS: ts})
+			if name == "Agent" {
+				// Delegation dispatch: give the roster a teammate name to bind the
+				// sub-agent to (subagent_type, else the task description).
+				ti := map[string]any{"name": firstStr(args, "subagent_type", "description")}
+				out = append(out, normalizedEvent{Event: "PreToolUse", ToolName: "Agent", ToolInput: ti, ToolUseID: id, AgentID: agentID, TS: ts})
+				break
+			}
+			out = append(out, normalizedEvent{Event: "PreToolUse", ToolName: name, ToolInput: args, ToolUseID: id, AgentID: agentID, TS: ts})
 		case "tool.result":
 			id := str(ev["toolCallId"])
-			out = append(out, normalizedEvent{Event: "PostToolUse", ToolName: callTool[id], ToolUseID: id, TS: ts})
+			out = append(out, normalizedEvent{Event: "PostToolUse", ToolName: callTool[id], ToolUseID: id, AgentID: agentID, TS: ts})
 		}
 	}
-	if err := sc.Err(); err != nil {
-		return nil, err
+	return out, sc.Err()
+}
+
+// kimiAgentType reads a sub-agent's profile (its type) from its first
+// config.update event.
+func kimiAgentType(wirePath string) string {
+	f, err := os.Open(wirePath)
+	if err != nil {
+		return ""
 	}
-	return encodeEvents(out)
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1024*1024), 8*1024*1024)
+	for sc.Scan() {
+		var o map[string]any
+		if json.Unmarshal(sc.Bytes(), &o) != nil {
+			continue
+		}
+		if o["type"] == "config.update" {
+			if p := str(o["profileName"]); p != "" && p != "agent" {
+				return p
+			}
+		}
+	}
+	return ""
 }
 
 // adaptCodexRollout maps OpenAI Codex CLI's session rollout-*.jsonl onto

--- a/internal/hooksbridge/adapters.go
+++ b/internal/hooksbridge/adapters.go
@@ -1,0 +1,186 @@
+package hooksbridge
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// AdaptHarness wraps a harness-specific session transcript in a reader of the
+// normalized hook-JSONL events Ingest consumes, so a non-Claude-Code harness is
+// captured by translating its OWN session record — no per-harness bespoke bridge.
+// harness "" / "claude" is a passthrough (the events are already normalized).
+func AdaptHarness(harness string, r io.Reader) (io.Reader, error) {
+	switch harness {
+	case "", "claude":
+		return r, nil
+	case "kimi":
+		return adaptKimiWire(r)
+	case "codex":
+		return adaptCodexRollout(r)
+	default:
+		return nil, fmt.Errorf("hooksbridge: unknown harness %q (want claude|kimi|codex)", harness)
+	}
+}
+
+// normalizedEvent is one hook-JSONL line in the schema parseEvent reads.
+type normalizedEvent struct {
+	Event     string         `json:"hook_event_name"`
+	ToolName  string         `json:"tool_name,omitempty"`
+	ToolInput map[string]any `json:"tool_input,omitempty"`
+	ToolUseID string         `json:"tool_use_id,omitempty"`
+	AgentID   string         `json:"agent_id,omitempty"`
+	TS        string         `json:"timestamp,omitempty"`
+	LastMsg   string         `json:"last_assistant_message,omitempty"`
+}
+
+func encodeEvents(evs []normalizedEvent) (io.Reader, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, e := range evs {
+		if err := enc.Encode(e); err != nil {
+			return nil, err
+		}
+	}
+	return &buf, nil
+}
+
+// adaptKimiWire maps Kimi Code CLI's per-agent wire.jsonl (an internal event
+// stream) onto normalized hook events. Kimi's tool.call/tool.result carry the
+// same tool NAMES as Claude Code (Read/Write/Bash/Edit), so command-match to
+// kernel syscalls works unchanged. tool.call -> PreToolUse, tool.result ->
+// PostToolUse.
+func adaptKimiWire(r io.Reader) (io.Reader, error) {
+	var out []normalizedEvent
+	callTool := map[string]string{} // toolCallId -> tool name (to label the result)
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 1024*1024), 8*1024*1024)
+	for sc.Scan() {
+		var top map[string]any
+		if json.Unmarshal(sc.Bytes(), &top) != nil {
+			continue
+		}
+		ev := top
+		if t, _ := top["type"].(string); t == "context.append_loop_event" {
+			if inner, ok := top["event"].(map[string]any); ok {
+				ev = inner
+			}
+		}
+		ts := stampFromUnixMillis(top["time"], top["ts"])
+		switch ev["type"] {
+		case "tool.call":
+			id := str(ev["toolCallId"])
+			name := str(ev["name"])
+			callTool[id] = name
+			args, _ := ev["args"].(map[string]any)
+			out = append(out, normalizedEvent{Event: "PreToolUse", ToolName: name, ToolInput: args, ToolUseID: id, TS: ts})
+		case "tool.result":
+			id := str(ev["toolCallId"])
+			out = append(out, normalizedEvent{Event: "PostToolUse", ToolName: callTool[id], ToolUseID: id, TS: ts})
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return encodeEvents(out)
+}
+
+// adaptCodexRollout maps OpenAI Codex CLI's session rollout-*.jsonl onto
+// normalized hook events. Codex records response items; a function_call item is
+// the agent's tool call (name + arguments), its output the result.
+func adaptCodexRollout(r io.Reader) (io.Reader, error) {
+	var out []normalizedEvent
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 1024*1024), 8*1024*1024)
+	for sc.Scan() {
+		var top map[string]any
+		if json.Unmarshal(sc.Bytes(), &top) != nil {
+			continue
+		}
+		ts := str(top["timestamp"])
+		payload, _ := top["payload"].(map[string]any)
+		if payload == nil {
+			continue
+		}
+		// Codex wraps items as {type:"response_item", payload:{type:"function_call"|"local_shell_call"|..., name, arguments, call_id}}.
+		itemType := firstStr(payload, "type")
+		switch itemType {
+		case "function_call", "local_shell_call", "custom_tool_call":
+			name := firstStr(payload, "name")
+			if name == "" && itemType == "local_shell_call" {
+				name = "Bash"
+			}
+			ti := codexArgs(payload)
+			out = append(out, normalizedEvent{Event: "PreToolUse", ToolName: name, ToolInput: ti, ToolUseID: firstStr(payload, "call_id", "id"), TS: ts})
+		case "function_call_output", "local_shell_call_output", "custom_tool_call_output":
+			out = append(out, normalizedEvent{Event: "PostToolUse", ToolUseID: firstStr(payload, "call_id", "id"), TS: ts})
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return encodeEvents(out)
+}
+
+// codexArgs turns a codex tool item into a tool_input map, decoding the JSON
+// `arguments` string when present (function_call) or lifting a shell command.
+func codexArgs(payload map[string]any) map[string]any {
+	if raw := firstStr(payload, "arguments"); raw != "" {
+		var m map[string]any
+		if json.Unmarshal([]byte(raw), &m) == nil {
+			return m
+		}
+	}
+	if cmd, ok := payload["command"]; ok {
+		return map[string]any{"command": commandString(cmd)}
+	}
+	return nil
+}
+
+func commandString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case []any:
+		parts := make([]string, 0, len(t))
+		for _, p := range t {
+			parts = append(parts, str(p))
+		}
+		return joinSpace(parts)
+	}
+	return ""
+}
+
+func str(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func joinSpace(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += " "
+		}
+		out += p
+	}
+	return out
+}
+
+// stampFromUnixMillis renders the first present unix-millis timestamp as RFC3339.
+func stampFromUnixMillis(vals ...any) string {
+	for _, v := range vals {
+		if f, ok := v.(float64); ok && f > 0 {
+			return time.UnixMilli(int64(f)).UTC().Format(time.RFC3339Nano)
+		}
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/hooksbridge/adapters_test.go
+++ b/internal/hooksbridge/adapters_test.go
@@ -60,7 +60,9 @@ func TestAdaptCodexRolloutMapsFunctionCalls(t *testing.T) {
 		`{"timestamp":"2026-07-09T05:49:40Z","type":"session_meta","payload":{"session_id":"s1"}}`,
 		`{"timestamp":"2026-07-09T05:49:41Z","type":"response_item","payload":{"type":"function_call","name":"read_file","arguments":"{\"path\":\"/etc/hosts\"}","call_id":"f1"}}`,
 		`{"timestamp":"2026-07-09T05:49:42Z","type":"response_item","payload":{"type":"local_shell_call","command":["python3","setup.py","install"],"call_id":"s2"}}`,
-		`{"timestamp":"2026-07-09T05:49:43Z","type":"response_item","payload":{"type":"function_call_output","call_id":"f1"}}`,
+		// The real codex shell tool: exec_command with a `cmd` string -> Bash.
+		`{"timestamp":"2026-07-09T05:49:43Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"echo banana > hello.txt\"}","call_id":"e3"}}`,
+		`{"timestamp":"2026-07-09T05:49:44Z","type":"response_item","payload":{"type":"function_call_output","call_id":"f1"}}`,
 	}, "\n")
 
 	r, err := AdaptHarness("codex", strings.NewReader(rollout))
@@ -68,8 +70,8 @@ func TestAdaptCodexRolloutMapsFunctionCalls(t *testing.T) {
 		t.Fatal(err)
 	}
 	evs := decodeAdapted(t, r)
-	if len(evs) != 3 {
-		t.Fatalf("got %d events, want 3: %+v", len(evs), evs)
+	if len(evs) != 4 {
+		t.Fatalf("got %d events, want 4: %+v", len(evs), evs)
 	}
 	if evs[0].ToolName != "read_file" || evs[0].ToolInput["path"] != "/etc/hosts" {
 		t.Fatalf("function_call args not decoded: %+v", evs[0])
@@ -77,8 +79,11 @@ func TestAdaptCodexRolloutMapsFunctionCalls(t *testing.T) {
 	if evs[1].ToolName != "Bash" || evs[1].ToolInput["command"] != "python3 setup.py install" {
 		t.Fatalf("shell argv not joined to a command: %+v", evs[1])
 	}
-	if evs[2].Event != "PostToolUse" || evs[2].ToolUseID != "f1" {
-		t.Fatalf("output not mapped: %+v", evs[2])
+	if evs[2].ToolName != "Bash" || evs[2].ToolInput["command"] != "echo banana > hello.txt" {
+		t.Fatalf("exec_command not normalized to Bash+command: %+v", evs[2])
+	}
+	if evs[3].Event != "PostToolUse" || evs[3].ToolUseID != "f1" {
+		t.Fatalf("output not mapped: %+v", evs[3])
 	}
 }
 

--- a/internal/hooksbridge/adapters_test.go
+++ b/internal/hooksbridge/adapters_test.go
@@ -3,6 +3,8 @@ package hooksbridge
 import (
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -77,6 +79,53 @@ func TestAdaptCodexRolloutMapsFunctionCalls(t *testing.T) {
 	}
 	if evs[2].Event != "PostToolUse" || evs[2].ToolUseID != "f1" {
 		t.Fatalf("output not mapped: %+v", evs[2])
+	}
+}
+
+func TestAdaptKimiSessionCapturesDelegation(t *testing.T) {
+	// A Kimi multi-agent session: main dispatches an `Agent` (subagent_type=coder),
+	// and agents/agent-0/ is that sub-agent doing the work. The adapter must yield
+	// the same delegation shape Claude Code does: an Agent dispatch + a SubagentStart.
+	dir := t.TempDir()
+	main := filepath.Join(dir, "agents", "main")
+	sub := filepath.Join(dir, "agents", "agent-0")
+	if err := os.MkdirAll(main, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mainWire := `{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"a1","name":"Agent","args":{"subagent_type":"coder","description":"read calc.py"}}}`
+	subWire := strings.Join([]string{
+		`{"type":"config.update","profileName":"coder"}`,
+		`{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"r1","name":"Read","args":{"path":"/tmp/calc.py"}}}`,
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(main, "wire.jsonl"), []byte(mainWire), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "wire.jsonl"), []byte(subWire), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := AdaptKimiSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := decodeAdapted(t, r)
+	var dispatch, substart, subread bool
+	for _, e := range evs {
+		if e.Event == "PreToolUse" && e.ToolName == "Agent" && e.ToolInput["name"] == "coder" {
+			dispatch = true
+		}
+		if e.Event == "SubagentStart" && e.AgentID == "agent-0" && e.AgentType == "coder" {
+			substart = true
+		}
+		if e.Event == "PreToolUse" && e.ToolName == "Read" && e.AgentID == "agent-0" {
+			subread = true
+		}
+	}
+	if !dispatch || !substart || !subread {
+		t.Fatalf("delegation not captured (dispatch=%v substart=%v subread=%v): %+v", dispatch, substart, subread, evs)
 	}
 }
 

--- a/internal/hooksbridge/adapters_test.go
+++ b/internal/hooksbridge/adapters_test.go
@@ -1,0 +1,87 @@
+package hooksbridge
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func decodeAdapted(t *testing.T, r io.Reader) []normalizedEvent {
+	t.Helper()
+	var out []normalizedEvent
+	dec := json.NewDecoder(r)
+	for dec.More() {
+		var e normalizedEvent
+		if err := dec.Decode(&e); err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func TestAdaptKimiWireMapsToolCalls(t *testing.T) {
+	// Kimi wraps its events in context.append_loop_event; tool.call carries the
+	// same tool NAMES as Claude Code, so command-match works unchanged.
+	wire := strings.Join([]string{
+		`{"type":"metadata","protocol_version":"1.4"}`,
+		`{"type":"turn.prompt","input":[{"type":"text","text":"do it"}]}`,
+		`{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"c1","name":"Bash","args":{"command":"python3 setup.py install"}},"time":1783581116451}`,
+		`{"type":"context.append_loop_event","event":{"type":"tool.result","toolCallId":"c1","result":{"output":"ok"}},"time":1783581116999}`,
+		`{"type":"context.append_loop_event","event":{"type":"tool.call","toolCallId":"c2","name":"Read","args":{"path":"/etc/hosts"}}}`,
+	}, "\n")
+
+	r, err := AdaptHarness("kimi", strings.NewReader(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := decodeAdapted(t, r)
+	if len(evs) != 3 {
+		t.Fatalf("got %d events, want 3 (2 PreToolUse + 1 PostToolUse): %+v", len(evs), evs)
+	}
+	if evs[0].Event != "PreToolUse" || evs[0].ToolName != "Bash" || evs[0].ToolInput["command"] != "python3 setup.py install" {
+		t.Fatalf("first event wrong: %+v", evs[0])
+	}
+	if evs[1].Event != "PostToolUse" || evs[1].ToolUseID != "c1" || evs[1].ToolName != "Bash" {
+		t.Fatalf("result not labeled with its call's tool: %+v", evs[1])
+	}
+	if evs[2].ToolName != "Read" || evs[2].ToolInput["path"] != "/etc/hosts" {
+		t.Fatalf("read call wrong: %+v", evs[2])
+	}
+}
+
+func TestAdaptCodexRolloutMapsFunctionCalls(t *testing.T) {
+	// Codex records response items; a function_call / local_shell_call is a tool
+	// call whose arguments are a JSON string (function) or an argv (shell).
+	rollout := strings.Join([]string{
+		`{"timestamp":"2026-07-09T05:49:40Z","type":"session_meta","payload":{"session_id":"s1"}}`,
+		`{"timestamp":"2026-07-09T05:49:41Z","type":"response_item","payload":{"type":"function_call","name":"read_file","arguments":"{\"path\":\"/etc/hosts\"}","call_id":"f1"}}`,
+		`{"timestamp":"2026-07-09T05:49:42Z","type":"response_item","payload":{"type":"local_shell_call","command":["python3","setup.py","install"],"call_id":"s2"}}`,
+		`{"timestamp":"2026-07-09T05:49:43Z","type":"response_item","payload":{"type":"function_call_output","call_id":"f1"}}`,
+	}, "\n")
+
+	r, err := AdaptHarness("codex", strings.NewReader(rollout))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := decodeAdapted(t, r)
+	if len(evs) != 3 {
+		t.Fatalf("got %d events, want 3: %+v", len(evs), evs)
+	}
+	if evs[0].ToolName != "read_file" || evs[0].ToolInput["path"] != "/etc/hosts" {
+		t.Fatalf("function_call args not decoded: %+v", evs[0])
+	}
+	if evs[1].ToolName != "Bash" || evs[1].ToolInput["command"] != "python3 setup.py install" {
+		t.Fatalf("shell argv not joined to a command: %+v", evs[1])
+	}
+	if evs[2].Event != "PostToolUse" || evs[2].ToolUseID != "f1" {
+		t.Fatalf("output not mapped: %+v", evs[2])
+	}
+}
+
+func TestAdaptHarnessUnknownRejected(t *testing.T) {
+	if _, err := AdaptHarness("langchain", strings.NewReader("")); err == nil {
+		t.Fatal("unknown harness should error")
+	}
+}

--- a/internal/sensor/sensor_linux.go
+++ b/internal/sensor/sensor_linux.go
@@ -179,6 +179,12 @@ func RunWithOptions(out io.Writer, opts Options) error {
 		if !attachedWrite || !attachedRead {
 			return fmt.Errorf("attach OpenSSL TLS uprobes on %s: write=%v read=%v (%s)", opts.SSLLib, attachedWrite, attachedRead, strings.Join(attachErrs, "; "))
 		}
+		// A partial attach is non-fatal but silently loses a direction (e.g. a
+		// client that only calls SSL_read_ex would go dark if its return probe
+		// failed while SSL_read's succeeded). Surface it so it isn't a mystery.
+		if len(attachErrs) > 0 {
+			fmt.Fprintf(os.Stderr, "agentprov-sensor: partial TLS uprobe attach on %s: %s\n", opts.SSLLib, strings.Join(attachErrs, "; "))
+		}
 	}
 
 	// Go crypto/tls: Go agents use Go's own TLS stack (no libssl), so the SSLLib

--- a/internal/sensor/sensor_other.go
+++ b/internal/sensor/sensor_other.go
@@ -15,6 +15,7 @@ import (
 type Options struct {
 	SSLLib   string
 	GoTLSBin string
+	LibcLib  string
 	OnReady  func()
 }
 

--- a/internal/tlsintent/reassembler.go
+++ b/internal/tlsintent/reassembler.go
@@ -112,6 +112,18 @@ func (r *Reassembler) Add(c Chunk) []Message {
 	if len(c.Data) == 0 && !c.Truncated {
 		return nil
 	}
+	// A new request on this connection means any buffered response for it has
+	// completed: HTTP/1.1 is strictly request→response→request, so the client only
+	// sends again after fully reading the prior response — and the SSL* pointer is
+	// commonly freed+reused for the next connection. This is the ONLY in-band
+	// completion signal for a close-framed response (no Content-Length, no chunked
+	// terminator), which otherwise sits buffered until process-exit Flush and is
+	// lost on a long-lived workload. Flush it here so the response isn't dropped.
+	var flushed []Message
+	if c.Direction == Request {
+		flushed = r.flushDir(c.PID, c.Conn, Response)
+	}
+
 	k := streamKey{c.PID, c.Conn, c.Direction}
 	s := r.streams[k]
 	if s == nil {
@@ -146,9 +158,9 @@ func (r *Reassembler) Add(c Chunk) []Message {
 			pre := append([]byte(nil), s.buf.Bytes()...)
 			s.buf.Reset()
 			out := s.h2.consume(pre, c.PID, c.Conn)
-			return append(out, s.h2.consume(c.Data, c.PID, c.Conn)...)
+			return append(flushed, append(out, s.h2.consume(c.Data, c.PID, c.Conn)...)...)
 		}
-		return s.h2.consume(c.Data, c.PID, c.Conn)
+		return append(flushed, s.h2.consume(c.Data, c.PID, c.Conn)...)
 	}
 
 	max := r.MaxBytes
@@ -174,7 +186,7 @@ func (r *Reassembler) Add(c Chunk) []Message {
 		s.buf.Write(rest)
 		s.truncated = false
 	}
-	return out
+	return append(flushed, out...)
 }
 
 // Flush emits whatever is buffered for a connection as a best-effort (possibly
@@ -184,26 +196,34 @@ func (r *Reassembler) Add(c Chunk) []Message {
 func (r *Reassembler) Flush(pid uint32, conn uint64) []Message {
 	var out []Message
 	for _, dir := range []string{Request, Response} {
-		k := streamKey{pid, conn, dir}
-		s := r.streams[k]
-		if s == nil {
-			continue
-		}
-		if s.h2 != nil {
-			out = append(out, s.h2.flush(pid, conn)...)
-			delete(r.streams, k)
-			continue
-		}
-		if s.buf.Len() == 0 {
-			continue
-		}
-		if msg, ok := parseBestEffort(pid, conn, dir, s.buf.Bytes(), s.isH2); ok {
-			msg.Truncated = true
-			out = append(out, msg)
-		}
-		delete(r.streams, k)
+		out = append(out, r.flushDir(pid, conn, dir)...)
 	}
 	delete(r.h2Conns, connKey{pid, conn})
+	return out
+}
+
+// flushDir emits whatever is buffered for one connection-direction as a
+// best-effort (possibly truncated) message and forgets that stream.
+func (r *Reassembler) flushDir(pid uint32, conn uint64, dir string) []Message {
+	k := streamKey{pid, conn, dir}
+	s := r.streams[k]
+	if s == nil {
+		return nil
+	}
+	var out []Message
+	if s.h2 != nil {
+		out = s.h2.flush(pid, conn)
+		delete(r.streams, k)
+		return out
+	}
+	if s.buf.Len() == 0 {
+		return nil
+	}
+	if msg, ok := parseBestEffort(pid, conn, dir, s.buf.Bytes(), s.isH2); ok {
+		msg.Truncated = true
+		out = append(out, msg)
+	}
+	delete(r.streams, k)
 	return out
 }
 

--- a/internal/tlsintent/reassembler_test.go
+++ b/internal/tlsintent/reassembler_test.go
@@ -81,6 +81,30 @@ func TestContentLengthResponse(t *testing.T) {
 	}
 }
 
+func TestCloseFramedResponseFlushedOnNextRequestSameConn(t *testing.T) {
+	// A close-framed response (no Content-Length, no chunked) has no in-band
+	// terminator, so parseOne can't complete it. On a reused SSL* connection the
+	// next request is the completion signal — the response must not be lost.
+	r := NewReassembler()
+	resp := "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n" +
+		`{"model":"deepseek-v4-flash","choices":[{"message":{"content":"hi"}}]}`
+	if msgs := r.Add(Chunk{PID: 1, Conn: 9, Direction: Response, Data: []byte(resp)}); len(msgs) != 0 {
+		t.Fatalf("close-framed response should buffer, not emit yet: got %d", len(msgs))
+	}
+	// A new request on the same conn (SSL* reused) flushes the pending response.
+	req := "POST /v2 HTTP/1.1\r\nHost: api.deepseek.com\r\nContent-Length: 0\r\n\r\n"
+	msgs := r.Add(Chunk{PID: 1, Conn: 9, Direction: Request, Data: []byte(req)})
+	var gotResp bool
+	for _, m := range msgs {
+		if m.Direction == Response && m.Status == 200 && m.Model == "deepseek-v4-flash" {
+			gotResp = true
+		}
+	}
+	if !gotResp {
+		t.Fatalf("pending close-framed response not flushed on next request: %+v", msgs)
+	}
+}
+
 func TestChunkedResponse(t *testing.T) {
 	r := NewReassembler()
 	body := chunkedBody(`{"model":"claude-opus-4-8",`, `"content":"hello"}`)


### PR DESCRIPTION
## v0.7.1

Follow-on to v0.7.0's Portable Producer Profiles. No core/schema change.

### Added
- **`sandbox capture`** — one-shot k8s pod attribution (12 manual steps → one command); `--container` for multi-container pods; points sensor uprobes at the pod's own libssl/libc for node-side model intent + DNS.
- **`sandbox watch`** — auto-attribution **phase-2 preview** (kubectl-polling control loop, honestly *not* an informer yet; single per-round sensor, so model-intent coverage is weaker than `capture`).
- **Egress → domains** — getaddrinfo uprobe on the pod's libc + dns_query↔connect correlation; egress shows `api.deepseek.com`, not just the IP.
- **Multi-harness app-context** (`hooks bridge --harness kimi|codex|claude`) — the major coding CLIs write rich session transcripts; a thin per-harness adapter normalizes each into the existing bridge. **Kimi Code** (single + multi-agent delegation, wall-clock-merged) and **Codex** (`exec_command` → Bash for command-match). All three harnesses validated end-to-end against live runs.

### Fixed
- **Node-side `tls_read` reliability** — close-framed responses on a reused SSL* connection were lost; a new request now flushes the pending response. tls_read went 0 → 1:1 with tls_write.

Gate: gofmt / vet / `-race` clean, full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)